### PR TITLE
fix(templates): cap vm_cores to 4 to match minimum supported host CPU count

### DIFF
--- a/scenarios/_init_lab/01_init_proxmox/stage_01-create_templates/templates/ubuntu_noble/03-template-vm-medium-06-8g-64g.yml
+++ b/scenarios/_init_lab/01_init_proxmox/stage_01-create_templates/templates/ubuntu_noble/03-template-vm-medium-06-8g-64g.yml
@@ -29,7 +29,7 @@
         vm_id: 9236
         vm_name: "template-vm-medium-06-8g-64g"
         vm_cpu: "host"
-        vm_cores: 6
+        vm_cores: 4
         vm_sockets: 1
         vm_memory: 8192
         vm_net_virtio_bridge: "vmbr140"        

--- a/scenarios/_init_lab/01_init_proxmox/stage_01-create_templates/templates/ubuntu_noble/04-template-vm-large-06-8g-64g.yml
+++ b/scenarios/_init_lab/01_init_proxmox/stage_01-create_templates/templates/ubuntu_noble/04-template-vm-large-06-8g-64g.yml
@@ -29,7 +29,7 @@
         vm_id: 9246
         vm_name: "template-vm-large-06-16g-100g"
         vm_cpu: "host"
-        vm_cores: 6
+        vm_cores: 4
         vm_sockets: 1
         vm_memory: 16384
         vm_net_virtio_bridge: "vmbr140"        

--- a/scenarios/_init_lab/01_init_proxmox/stage_01-create_templates/templates/ubuntu_noble/04-template-vm-large-08-8g-64g.yml
+++ b/scenarios/_init_lab/01_init_proxmox/stage_01-create_templates/templates/ubuntu_noble/04-template-vm-large-08-8g-64g.yml
@@ -29,7 +29,7 @@
         vm_id: 9248
         vm_name: "template-vm-large-06-16g-100g"
         vm_cpu: "host"
-        vm_cores: 8
+        vm_cores: 4
         vm_sockets: 1
         vm_memory: 16384
         vm_net_virtio_bridge: "vmbr140"

--- a/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-06-8g-64g.yml
+++ b/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-06-8g-64g.yml
@@ -61,7 +61,7 @@
         vm_id: 9236
         vm_name: "template-vm-medium-06-8g-64g"
         vm_cpu: "host"
-        vm_cores: 6
+        vm_cores: 4
         vm_sockets: 1
         vm_memory: 8192
         vm_net_virtio_bridge: "vmbr140"

--- a/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-06-8g-64g.yml
+++ b/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-06-8g-64g.yml
@@ -61,7 +61,7 @@
         vm_id: 9246
         vm_name: "template-vm-large-06-16g-100g"
         vm_cpu: "host"
-        vm_cores: 6
+        vm_cores: 4
         vm_sockets: 1
         vm_memory: 16384
         vm_net_virtio_bridge: "vmbr140"

--- a/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-08-8g-64g.yml
+++ b/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-08-8g-64g.yml
@@ -61,7 +61,7 @@
         vm_id: 9248
         vm_name: "template-vm-large-06-16g-100g"
         vm_cpu: "host"
-        vm_cores: 8
+        vm_cores: 4
         vm_sockets: 1
         vm_memory: 16384
         vm_net_virtio_bridge: "vmbr140"

--- a/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-06-8g-64g.yml
+++ b/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-06-8g-64g.yml
@@ -61,7 +61,7 @@
         vm_id: 9236
         vm_name: "template-vm-medium-06-8g-64g"
         vm_cpu: "host"
-        vm_cores: 6
+        vm_cores: 4
         vm_sockets: 1
         vm_memory: 8192
         vm_net_virtio_bridge: "vmbr140"

--- a/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-06-8g-64g.yml
+++ b/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-06-8g-64g.yml
@@ -61,7 +61,7 @@
         vm_id: 9246
         vm_name: "template-vm-large-06-16g-100g"
         vm_cpu: "host"
-        vm_cores: 6
+        vm_cores: 4
         vm_sockets: 1
         vm_memory: 16384
         vm_net_virtio_bridge: "vmbr140"

--- a/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-08-8g-64g.yml
+++ b/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-08-8g-64g.yml
@@ -61,7 +61,7 @@
         vm_id: 9248
         vm_name: "template-vm-large-06-16g-100g"
         vm_cpu: "host"
-        vm_cores: 8
+        vm_cores: 4
         vm_sockets: 1
         vm_memory: 16384
         vm_net_virtio_bridge: "vmbr140"

--- a/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-06-8g-64g.yml
+++ b/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-06-8g-64g.yml
@@ -61,7 +61,7 @@
         vm_id: 9236
         vm_name: "template-vm-medium-06-8g-64g"
         vm_cpu: "host"
-        vm_cores: 6
+        vm_cores: 4
         vm_sockets: 1
         vm_memory: 8192
         vm_net_virtio_bridge: "vmbr140"

--- a/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-06-8g-64g.yml
+++ b/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-06-8g-64g.yml
@@ -61,7 +61,7 @@
         vm_id: 9246
         vm_name: "template-vm-large-06-16g-100g"
         vm_cpu: "host"
-        vm_cores: 6
+        vm_cores: 4
         vm_sockets: 1
         vm_memory: 16384
         vm_net_virtio_bridge: "vmbr140"

--- a/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-08-8g-64g.yml
+++ b/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-08-8g-64g.yml
@@ -61,7 +61,7 @@
         vm_id: 9248
         vm_name: "template-vm-large-06-16g-100g"
         vm_cpu: "host"
-        vm_cores: 8
+        vm_cores: 4
         vm_sockets: 1
         vm_memory: 16384
         vm_net_virtio_bridge: "vmbr140"

--- a/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-06-8g-64g.yml
+++ b/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-06-8g-64g.yml
@@ -29,7 +29,7 @@
         vm_id: 9236
         vm_name: "template-vm-medium-06-8g-64g"
         vm_cpu: "host"
-        vm_cores: 6
+        vm_cores: 4
         vm_sockets: 1
         vm_memory: 8192
         vm_net_virtio_bridge: "vmbr140"

--- a/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-06-8g-64g.yml
+++ b/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-06-8g-64g.yml
@@ -29,7 +29,7 @@
         vm_id: 9246
         vm_name: "template-vm-large-06-16g-100g"
         vm_cpu: "host"
-        vm_cores: 6
+        vm_cores: 4
         vm_sockets: 1
         vm_memory: 16384
         vm_net_virtio_bridge: "vmbr140"

--- a/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-08-8g-64g.yml
+++ b/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-08-8g-64g.yml
@@ -29,7 +29,7 @@
         vm_id: 9248
         vm_name: "template-vm-large-06-16g-100g"
         vm_cpu: "host"
-        vm_cores: 8
+        vm_cores: 4
         vm_sockets: 1
         vm_memory: 16384
         vm_net_virtio_bridge: "vmbr140"


### PR DESCRIPTION
Fixes #43

## Summary

- Cap `vm_cores` from 6/8 → 4 in the `medium-06`, `large-06`, and `large-08` template files across all scenarios (`blank_scenario_2_subnets`, `blank_scenario_4_subnets`, `blank_scenario_6_subnets`, `demo_lab`, `_init_lab`)
- 15 files changed, 1-line fix each

## Root cause

Proxmox enforces that a VM cannot be allocated more vCPUs than the host has physical CPUs. On a host with 4 physical CPUs, templates with `vm_cores: 6` or `vm_cores: 8` fail to start during `TEMPLATES UPDATE - START all templates` with `MAX 4 vcpus allowed per VM on this node`, blocking the entire template update play and all subsequent scenario deployment.

## Notes

- Template names (`-06-`, `-08-`) are left unchanged — they describe the intended sizing tier, not a guaranteed CPU count
- Operators with more physical CPUs can raise `vm_cores` in the template file or after cloning

## Test plan

- [ ] Run template update on a host with 4 physical CPUs — all templates start successfully
- [ ] Verify medium-06, large-06, large-08 templates finalize (cloud-init completes, VM converts to template)

---

**Closed — wrong approach.** Capping `vm_cores` changes the template spec and would cause VMs cloned from those templates to get fewer CPUs than intended. The correct fix is to handle the "MAX vcpus" error gracefully in `_update_templates.yml` (skip + warn) rather than modifying the template definitions. See issue #43 for the replacement fix.