### PR TITLE
fix(scenarios): guard delete/reset scripts against invalid JSON from proxmox_vm.list

### DIFF
--- a/scenarios/_init_lab/init_lab.delete_all.sh
+++ b/scenarios/_init_lab/init_lab.delete_all.sh
@@ -1,8 +1,14 @@
 #!/bin/bash 
 
 
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
 
 
 VM_INFRASTRUCTURE_IP=(

--- a/scenarios/_init_lab/init_lab.reset.setup.sh
+++ b/scenarios/_init_lab/init_lab.reset.setup.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
 
 
 VM_INFRASTRUCTURE_IP=(

--- a/scenarios/blank_scenario_2_subnets/blank_scenario_2_subnets.delete_all.sh
+++ b/scenarios/blank_scenario_2_subnets/blank_scenario_2_subnets.delete_all.sh
@@ -38,12 +38,14 @@ echo ":: scenario VMs: ${SCENARIO_VM_IDS[*]}"
 echo ":: templates   : ${TEMPLATE_VM_IDS[*]}"
 echo ""
 
-# the [WARNING] / jq parse error noise that may appear here comes from
-# proxmox_vm.list.to.jsons.sh (Ansible warnings leaking to stdout) — non-fatal,
-# the grep filter still catches the JSON lines properly. tracked separately.
-
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
 for ip in "${INFRASTRUCTURE_IP[@]}"; do
     echo ":: REMOVE SSH KEY FOR : $ip"

--- a/scenarios/blank_scenario_2_subnets/blank_scenario_2_subnets.delete_vms_only.sh
+++ b/scenarios/blank_scenario_2_subnets/blank_scenario_2_subnets.delete_vms_only.sh
@@ -29,8 +29,14 @@ echo ":: stopping and deleting scenario VMs (keeping templates)..."
 echo ":: scenario VMs: ${SCENARIO_VM_IDS[*]}"
 echo ""
 
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
 for ip in "${INFRASTRUCTURE_IP[@]}"; do
     echo ":: REMOVE SSH KEY FOR : $ip"

--- a/scenarios/blank_scenario_2_subnets/blank_scenario_2_subnets.reset.setup.sh
+++ b/scenarios/blank_scenario_2_subnets/blank_scenario_2_subnets.reset.setup.sh
@@ -9,8 +9,14 @@ ID_REGEX=$(printf '|%s' "${SCENARIO_VM_IDS[@]}" | sed 's/^|//')
 
 echo ":: stopping and deleting scenario VMs (vm_ids: ${SCENARIO_VM_IDS[*]})..."
 
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
 INFRASTRUCTURE_IP=(
     # team — vmbr143

--- a/scenarios/blank_scenario_4_subnets/blank_scenario_4_subnets.delete_all.sh
+++ b/scenarios/blank_scenario_4_subnets/blank_scenario_4_subnets.delete_all.sh
@@ -38,12 +38,14 @@ echo ":: scenario VMs: ${SCENARIO_VM_IDS[*]}"
 echo ":: templates   : ${TEMPLATE_VM_IDS[*]}"
 echo ""
 
-# the [WARNING] / jq parse error noise that may appear here comes from
-# proxmox_vm.list.to.jsons.sh (Ansible warnings leaking to stdout) — non-fatal,
-# the grep filter still catches the JSON lines properly. tracked separately.
-
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
 for ip in "${INFRASTRUCTURE_IP[@]}"; do
     echo ":: REMOVE SSH KEY FOR : $ip"

--- a/scenarios/blank_scenario_4_subnets/blank_scenario_4_subnets.delete_vms_only.sh
+++ b/scenarios/blank_scenario_4_subnets/blank_scenario_4_subnets.delete_vms_only.sh
@@ -29,8 +29,14 @@ echo ":: stopping and deleting scenario VMs (keeping templates)..."
 echo ":: scenario VMs: ${SCENARIO_VM_IDS[*]}"
 echo ""
 
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
 for ip in "${INFRASTRUCTURE_IP[@]}"; do
     echo ":: REMOVE SSH KEY FOR : $ip"

--- a/scenarios/blank_scenario_4_subnets/blank_scenario_4_subnets.reset.setup.sh
+++ b/scenarios/blank_scenario_4_subnets/blank_scenario_4_subnets.reset.setup.sh
@@ -19,8 +19,14 @@ ID_REGEX=$(printf '|%s' "${SCENARIO_VM_IDS[@]}" | sed 's/^|//')
 
 echo ":: stopping and deleting scenario VMs (vm_ids: ${SCENARIO_VM_IDS[*]})..."
 
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
 for ip in "${INFRASTRUCTURE_IP[@]}"; do
     echo ":: REMOVE SSH KEY FOR : $ip"

--- a/scenarios/blank_scenario_6_subnets/blank_scenario_6_subnets.delete_all.sh
+++ b/scenarios/blank_scenario_6_subnets/blank_scenario_6_subnets.delete_all.sh
@@ -37,12 +37,14 @@ echo ":: scenario VMs: ${SCENARIO_VM_IDS[*]}"
 echo ":: templates   : ${TEMPLATE_VM_IDS[*]}"
 echo ""
 
-# the [WARNING] / jq parse error noise that may appear here comes from
-# proxmox_vm.list.to.jsons.sh (Ansible warnings leaking to stdout) — non-fatal,
-# the grep filter still catches the JSON lines properly. tracked separately.
-
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
 for ip in "${INFRASTRUCTURE_IP[@]}"; do
     echo ":: REMOVE SSH KEY FOR : $ip"

--- a/scenarios/blank_scenario_6_subnets/blank_scenario_6_subnets.delete_vms_only.sh
+++ b/scenarios/blank_scenario_6_subnets/blank_scenario_6_subnets.delete_vms_only.sh
@@ -28,8 +28,14 @@ echo ":: stopping and deleting scenario VMs (keeping templates)..."
 echo ":: scenario VMs: ${SCENARIO_VM_IDS[*]}"
 echo ""
 
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
 for ip in "${INFRASTRUCTURE_IP[@]}"; do
     echo ":: REMOVE SSH KEY FOR : $ip"

--- a/scenarios/blank_scenario_6_subnets/blank_scenario_6_subnets.reset.setup.sh
+++ b/scenarios/blank_scenario_6_subnets/blank_scenario_6_subnets.reset.setup.sh
@@ -19,8 +19,14 @@ ID_REGEX=$(printf '|%s' "${SCENARIO_VM_IDS[@]}" | sed 's/^|//')
 
 echo ":: stopping and deleting scenario VMs (vm_ids: ${SCENARIO_VM_IDS[*]})..."
 
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
 for ip in "${INFRASTRUCTURE_IP[@]}"; do
     echo ":: REMOVE SSH KEY FOR : $ip"

--- a/scenarios/debug_scenario_a/debug_scenario_a.delete_all.sh
+++ b/scenarios/debug_scenario_a/debug_scenario_a.delete_all.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
 
 INFRASTRUCTURE_IP=(
     "192.168.147.250" # dsa-vm-01

--- a/scenarios/debug_scenario_a/debug_scenario_a.delete_vms_only.sh
+++ b/scenarios/debug_scenario_a/debug_scenario_a.delete_vms_only.sh
@@ -6,8 +6,14 @@
 
 echo ":: stopping and deleting VMs (keeping templates)..."
 
-proxmox_vm.list.to.jsons.sh | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.delete.to.jsons.sh
 
 INFRASTRUCTURE_IP=(
     "192.168.147.250" # dsa-vm-01

--- a/scenarios/debug_scenario_a/debug_scenario_a.reset.setup.sh
+++ b/scenarios/debug_scenario_a/debug_scenario_a.reset.setup.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
 
 INFRASTRUCTURE_IP=(
     "192.168.147.250" # dsa-vm-01

--- a/scenarios/debug_scenario_b/debug_scenario_b.delete_all.sh
+++ b/scenarios/debug_scenario_b/debug_scenario_b.delete_all.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
 
 INFRASTRUCTURE_IP=(
     "192.168.148.250" # dsb-vm-01

--- a/scenarios/debug_scenario_b/debug_scenario_b.delete_vms_only.sh
+++ b/scenarios/debug_scenario_b/debug_scenario_b.delete_vms_only.sh
@@ -6,8 +6,14 @@
 
 echo ":: stopping and deleting VMs (keeping templates)..."
 
-proxmox_vm.list.to.jsons.sh | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.delete.to.jsons.sh
 
 INFRASTRUCTURE_IP=(
     "192.168.148.250" # dsb-vm-01

--- a/scenarios/debug_scenario_b/debug_scenario_b.reset.setup.sh
+++ b/scenarios/debug_scenario_b/debug_scenario_b.reset.setup.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
 
 INFRASTRUCTURE_IP=(
     "192.168.148.250" # dsb-vm-01

--- a/scenarios/demo_lab/demo_lab.delete_all.sh
+++ b/scenarios/demo_lab/demo_lab.delete_all.sh
@@ -1,8 +1,14 @@
 #!/bin/bash 
 
 
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
 
 
 ADMIN_INFRASTRUCTURE_IP=(

--- a/scenarios/demo_lab/demo_lab.delete_vms_only.sh
+++ b/scenarios/demo_lab/demo_lab.delete_vms_only.sh
@@ -7,8 +7,14 @@
 
 echo ":: stopping and deleting VMs (keeping templates)..."
 
-proxmox_vm.list.to.jsons.sh | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.delete.to.jsons.sh
 
 INFRASTRUCTURE_IP=(
     "192.168.142.111" # testing-wazuh-client

--- a/scenarios/demo_lab/demo_lab.reset.setup.sh
+++ b/scenarios/demo_lab/demo_lab.reset.setup.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
 
 ADMIN_INFRASTRUCTURE_IP=(
     "192.168.142.111" # testing-wazuh-client


### PR DESCRIPTION
## Summary

- Captures `proxmox_vm.list.to.jsons.sh` output into a variable before processing in all delete and reset scripts
- Validates the output with `jq -e .` and aborts with a clear error if it is not valid JSON
- Reuses the captured output for both the stop and delete pipelines (one fewer API call per script)
- Removes the misleading "non-fatal" comment in `blank_scenario_2_subnets.delete_all.sh`

## Problem

All `delete_all.sh`, `delete_vms_only.sh`, and `reset.setup.sh` scripts piped `proxmox_vm.list.to.jsons.sh` directly into `jq -c` with no guard:

```bash
proxmox_vm.list.to.jsons.sh | jq -c | grep -E "..." | proxmox_vm.vm_id.stop_force.to.jsons.sh
proxmox_vm.list.to.jsons.sh | jq -c | grep -E "..." | proxmox_vm.vm_id.delete.to.jsons.sh
```

When the API returns an error string (stale token, Proxmox unreachable), `jq` emits a parse error and produces no output. The stop and delete commands receive no VM IDs — silently skipping all deletions while still exiting 0.

The `blank_scenario_2_subnets.delete_all.sh` even had a comment incorrectly calling this non-fatal. The comment described Ansible warning lines leaking into stdout, which are indeed harmless — but a full non-JSON error response from the API is not, and was being silently ignored.

## Affected files

20 scripts across all 7 scenarios: `blank_scenario_2/4/6_subnets`, `debug_scenario_a/b`, `demo_lab`, `_init_lab`

## Related

Closes #46
Same pattern fixed in `range42-context.sh` via range42/range42#110
Discovered during validation run for range42/range42#105