### PR TITLE
Dev - WAVE_01 tests - scenarios delete/reset guards

### DIFF
--- a/scenarios/_init_lab/init_lab.delete_all.sh
+++ b/scenarios/_init_lab/init_lab.delete_all.sh
@@ -1,8 +1,14 @@
 #!/bin/bash 
 
 
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
 
 
 VM_INFRASTRUCTURE_IP=(

--- a/scenarios/_init_lab/init_lab.delete_all.sh
+++ b/scenarios/_init_lab/init_lab.delete_all.sh
@@ -1,9 +1,9 @@
 #!/bin/bash 
 
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/_init_lab/init_lab.reset.setup.sh
+++ b/scenarios/_init_lab/init_lab.reset.setup.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
 
 
 VM_INFRASTRUCTURE_IP=(

--- a/scenarios/_init_lab/init_lab.reset.setup.sh
+++ b/scenarios/_init_lab/init_lab.reset.setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/_update_templates.yml
+++ b/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/_update_templates.yml
@@ -114,10 +114,36 @@
       failed_when:
         - start_result.rc != 0
         - "'already running' not in start_result.stderr"
+        - "'MAX' not in start_result.stderr"
       changed_when: start_result.rc == 0
       loop: "{{ templates_to_update }}"
       loop_control:
         label: "vm_id={{ item.vm_id }}"
+
+    # VMs that failed with "MAX X vcpus" couldn't start — exclude them from
+    # the wait/convert pipeline but keep the play running for the others.
+    - name: TEMPLATES UPDATE - BUILD started list (exclude CPU-limited VMs)
+      ansible.builtin.set_fact:
+        templates_started: >-
+          {{ templates_to_update | zip(start_result.results)
+                                 | rejectattr('1.stderr', 'search', 'MAX')
+                                 | map(attribute='0') | list }}
+        templates_skipped_cpu: >-
+          {{ templates_to_update | zip(start_result.results)
+                                 | selectattr('1.stderr', 'search', 'MAX')
+                                 | map(attribute='0') | list }}
+
+    - name: TEMPLATES UPDATE - WARN skipped templates (host CPU limit)
+      ansible.builtin.debug:
+        msg: |
+          WARNING: {{ templates_skipped_cpu | length }} template(s) skipped — host CPU limit:
+          {% for t in templates_skipped_cpu %}
+            - {{ t.vm_id }}  {{ t.vm_name }}  (spec: {{ t.spec }})
+          {% endfor %}
+          These templates require more vCPUs than this host provides.
+          They will NOT be converted. Run on a host with enough physical
+          CPUs, or lower vm_cores in the template playbook if intentional.
+      when: templates_skipped_cpu | length > 0
 
     #### #### #### wait until each VM auto-poweroffs (cloud-init done) #### #### ####
     # the loop is sequential per-vm, but since all started in parallel above,
@@ -130,7 +156,7 @@
       retries: 360                # safety cap : 360 × 5s = 30 min max per VM
       delay: 5
       until: stop_check.rc == 0
-      loop: "{{ templates_to_update }}"
+      loop: "{{ templates_started }}"
       loop_control:
         label: "vm_id={{ item.vm_id }}"
       changed_when: false
@@ -140,14 +166,14 @@
     - name: TEMPLATES UPDATE - DETACH bootstrap cicustom
       ansible.builtin.command:
         cmd: qm set {{ item.vm_id }} --delete cicustom
-      loop: "{{ templates_to_update }}"
+      loop: "{{ templates_started }}"
       loop_control:
         label: "vm_id={{ item.vm_id }}"
 
     - name: TEMPLATES UPDATE - RE-ATTACH apt-proxy cicustom (persistent for clones)
       ansible.builtin.command:
         cmd: qm set {{ item.vm_id }} --cicustom "vendor=local:snippets/range42-apt-proxy.yaml"
-      loop: "{{ templates_to_update }}"
+      loop: "{{ templates_started }}"
       loop_control:
         label: "vm_id={{ item.vm_id }}"
       when: (apt_proxy_url | default('')) | length > 0
@@ -155,7 +181,7 @@
     - name: TEMPLATES UPDATE - CONVERT VM to template
       ansible.builtin.command:
         cmd: qm template {{ item.vm_id }}
-      loop: "{{ templates_to_update }}"
+      loop: "{{ templates_started }}"
       loop_control:
         label: "vm_id={{ item.vm_id }}"
 
@@ -169,5 +195,8 @@
     - name: TEMPLATES UPDATE - DISPLAY DONE
       ansible.builtin.debug:
         msg: |
-          ✓ {{ templates | length }} templates updated and converted
+          ✓ {{ templates_started | length }} templates updated and converted
           ✓ apt-proxy cicustom re-attached (if apt_proxy_url set)
+          {% if templates_skipped_cpu | length > 0 %}
+          ⚠  {{ templates_skipped_cpu | length }} skipped (host CPU limit) — see warning above
+          {% endif %}

--- a/scenarios/blank_scenario_2_subnets/blank_scenario_2_subnets.delete_all.sh
+++ b/scenarios/blank_scenario_2_subnets/blank_scenario_2_subnets.delete_all.sh
@@ -38,12 +38,14 @@ echo ":: scenario VMs: ${SCENARIO_VM_IDS[*]}"
 echo ":: templates   : ${TEMPLATE_VM_IDS[*]}"
 echo ""
 
-# the [WARNING] / jq parse error noise that may appear here comes from
-# proxmox_vm.list.to.jsons.sh (Ansible warnings leaking to stdout) — non-fatal,
-# the grep filter still catches the JSON lines properly. tracked separately.
-
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
 for ip in "${INFRASTRUCTURE_IP[@]}"; do
     echo ":: REMOVE SSH KEY FOR : $ip"

--- a/scenarios/blank_scenario_2_subnets/blank_scenario_2_subnets.delete_all.sh
+++ b/scenarios/blank_scenario_2_subnets/blank_scenario_2_subnets.delete_all.sh
@@ -38,9 +38,9 @@ echo ":: scenario VMs: ${SCENARIO_VM_IDS[*]}"
 echo ":: templates   : ${TEMPLATE_VM_IDS[*]}"
 echo ""
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/blank_scenario_2_subnets/blank_scenario_2_subnets.delete_vms_only.sh
+++ b/scenarios/blank_scenario_2_subnets/blank_scenario_2_subnets.delete_vms_only.sh
@@ -29,9 +29,9 @@ echo ":: stopping and deleting scenario VMs (keeping templates)..."
 echo ":: scenario VMs: ${SCENARIO_VM_IDS[*]}"
 echo ""
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/blank_scenario_2_subnets/blank_scenario_2_subnets.delete_vms_only.sh
+++ b/scenarios/blank_scenario_2_subnets/blank_scenario_2_subnets.delete_vms_only.sh
@@ -29,8 +29,14 @@ echo ":: stopping and deleting scenario VMs (keeping templates)..."
 echo ":: scenario VMs: ${SCENARIO_VM_IDS[*]}"
 echo ""
 
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
 for ip in "${INFRASTRUCTURE_IP[@]}"; do
     echo ":: REMOVE SSH KEY FOR : $ip"

--- a/scenarios/blank_scenario_2_subnets/blank_scenario_2_subnets.reset.setup.sh
+++ b/scenarios/blank_scenario_2_subnets/blank_scenario_2_subnets.reset.setup.sh
@@ -9,8 +9,14 @@ ID_REGEX=$(printf '|%s' "${SCENARIO_VM_IDS[@]}" | sed 's/^|//')
 
 echo ":: stopping and deleting scenario VMs (vm_ids: ${SCENARIO_VM_IDS[*]})..."
 
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
 INFRASTRUCTURE_IP=(
     # team — vmbr143

--- a/scenarios/blank_scenario_2_subnets/blank_scenario_2_subnets.reset.setup.sh
+++ b/scenarios/blank_scenario_2_subnets/blank_scenario_2_subnets.reset.setup.sh
@@ -9,9 +9,9 @@ ID_REGEX=$(printf '|%s' "${SCENARIO_VM_IDS[@]}" | sed 's/^|//')
 
 echo ":: stopping and deleting scenario VMs (vm_ids: ${SCENARIO_VM_IDS[*]})..."
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/_update_templates.yml
+++ b/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/_update_templates.yml
@@ -114,10 +114,36 @@
       failed_when:
         - start_result.rc != 0
         - "'already running' not in start_result.stderr"
+        - "'MAX' not in start_result.stderr"
       changed_when: start_result.rc == 0
       loop: "{{ templates_to_update }}"
       loop_control:
         label: "vm_id={{ item.vm_id }}"
+
+    # VMs that failed with "MAX X vcpus" couldn't start — exclude them from
+    # the wait/convert pipeline but keep the play running for the others.
+    - name: TEMPLATES UPDATE - BUILD started list (exclude CPU-limited VMs)
+      ansible.builtin.set_fact:
+        templates_started: >-
+          {{ templates_to_update | zip(start_result.results)
+                                 | rejectattr('1.stderr', 'search', 'MAX')
+                                 | map(attribute='0') | list }}
+        templates_skipped_cpu: >-
+          {{ templates_to_update | zip(start_result.results)
+                                 | selectattr('1.stderr', 'search', 'MAX')
+                                 | map(attribute='0') | list }}
+
+    - name: TEMPLATES UPDATE - WARN skipped templates (host CPU limit)
+      ansible.builtin.debug:
+        msg: |
+          WARNING: {{ templates_skipped_cpu | length }} template(s) skipped — host CPU limit:
+          {% for t in templates_skipped_cpu %}
+            - {{ t.vm_id }}  {{ t.vm_name }}  (spec: {{ t.spec }})
+          {% endfor %}
+          These templates require more vCPUs than this host provides.
+          They will NOT be converted. Run on a host with enough physical
+          CPUs, or lower vm_cores in the template playbook if intentional.
+      when: templates_skipped_cpu | length > 0
 
     #### #### #### wait until each VM auto-poweroffs (cloud-init done) #### #### ####
     # the loop is sequential per-vm, but since all started in parallel above,
@@ -130,7 +156,7 @@
       retries: 360                # safety cap : 360 × 5s = 30 min max per VM
       delay: 5
       until: stop_check.rc == 0
-      loop: "{{ templates_to_update }}"
+      loop: "{{ templates_started }}"
       loop_control:
         label: "vm_id={{ item.vm_id }}"
       changed_when: false
@@ -140,14 +166,14 @@
     - name: TEMPLATES UPDATE - DETACH bootstrap cicustom
       ansible.builtin.command:
         cmd: qm set {{ item.vm_id }} --delete cicustom
-      loop: "{{ templates_to_update }}"
+      loop: "{{ templates_started }}"
       loop_control:
         label: "vm_id={{ item.vm_id }}"
 
     - name: TEMPLATES UPDATE - RE-ATTACH apt-proxy cicustom (persistent for clones)
       ansible.builtin.command:
         cmd: qm set {{ item.vm_id }} --cicustom "vendor=local:snippets/range42-apt-proxy.yaml"
-      loop: "{{ templates_to_update }}"
+      loop: "{{ templates_started }}"
       loop_control:
         label: "vm_id={{ item.vm_id }}"
       when: (apt_proxy_url | default('')) | length > 0
@@ -155,7 +181,7 @@
     - name: TEMPLATES UPDATE - CONVERT VM to template
       ansible.builtin.command:
         cmd: qm template {{ item.vm_id }}
-      loop: "{{ templates_to_update }}"
+      loop: "{{ templates_started }}"
       loop_control:
         label: "vm_id={{ item.vm_id }}"
 
@@ -169,5 +195,8 @@
     - name: TEMPLATES UPDATE - DISPLAY DONE
       ansible.builtin.debug:
         msg: |
-          ✓ {{ templates | length }} templates updated and converted
+          ✓ {{ templates_started | length }} templates updated and converted
           ✓ apt-proxy cicustom re-attached (if apt_proxy_url set)
+          {% if templates_skipped_cpu | length > 0 %}
+          ⚠  {{ templates_skipped_cpu | length }} skipped (host CPU limit) — see warning above
+          {% endif %}

--- a/scenarios/blank_scenario_4_subnets/blank_scenario_4_subnets.delete_all.sh
+++ b/scenarios/blank_scenario_4_subnets/blank_scenario_4_subnets.delete_all.sh
@@ -38,12 +38,14 @@ echo ":: scenario VMs: ${SCENARIO_VM_IDS[*]}"
 echo ":: templates   : ${TEMPLATE_VM_IDS[*]}"
 echo ""
 
-# the [WARNING] / jq parse error noise that may appear here comes from
-# proxmox_vm.list.to.jsons.sh (Ansible warnings leaking to stdout) — non-fatal,
-# the grep filter still catches the JSON lines properly. tracked separately.
-
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
 for ip in "${INFRASTRUCTURE_IP[@]}"; do
     echo ":: REMOVE SSH KEY FOR : $ip"

--- a/scenarios/blank_scenario_4_subnets/blank_scenario_4_subnets.delete_all.sh
+++ b/scenarios/blank_scenario_4_subnets/blank_scenario_4_subnets.delete_all.sh
@@ -38,9 +38,9 @@ echo ":: scenario VMs: ${SCENARIO_VM_IDS[*]}"
 echo ":: templates   : ${TEMPLATE_VM_IDS[*]}"
 echo ""
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/blank_scenario_4_subnets/blank_scenario_4_subnets.delete_vms_only.sh
+++ b/scenarios/blank_scenario_4_subnets/blank_scenario_4_subnets.delete_vms_only.sh
@@ -29,9 +29,9 @@ echo ":: stopping and deleting scenario VMs (keeping templates)..."
 echo ":: scenario VMs: ${SCENARIO_VM_IDS[*]}"
 echo ""
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/blank_scenario_4_subnets/blank_scenario_4_subnets.delete_vms_only.sh
+++ b/scenarios/blank_scenario_4_subnets/blank_scenario_4_subnets.delete_vms_only.sh
@@ -29,8 +29,14 @@ echo ":: stopping and deleting scenario VMs (keeping templates)..."
 echo ":: scenario VMs: ${SCENARIO_VM_IDS[*]}"
 echo ""
 
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
 for ip in "${INFRASTRUCTURE_IP[@]}"; do
     echo ":: REMOVE SSH KEY FOR : $ip"

--- a/scenarios/blank_scenario_4_subnets/blank_scenario_4_subnets.reset.setup.sh
+++ b/scenarios/blank_scenario_4_subnets/blank_scenario_4_subnets.reset.setup.sh
@@ -19,9 +19,9 @@ ID_REGEX=$(printf '|%s' "${SCENARIO_VM_IDS[@]}" | sed 's/^|//')
 
 echo ":: stopping and deleting scenario VMs (vm_ids: ${SCENARIO_VM_IDS[*]})..."
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/blank_scenario_4_subnets/blank_scenario_4_subnets.reset.setup.sh
+++ b/scenarios/blank_scenario_4_subnets/blank_scenario_4_subnets.reset.setup.sh
@@ -19,8 +19,14 @@ ID_REGEX=$(printf '|%s' "${SCENARIO_VM_IDS[@]}" | sed 's/^|//')
 
 echo ":: stopping and deleting scenario VMs (vm_ids: ${SCENARIO_VM_IDS[*]})..."
 
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
 for ip in "${INFRASTRUCTURE_IP[@]}"; do
     echo ":: REMOVE SSH KEY FOR : $ip"

--- a/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/_update_templates.yml
+++ b/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/_update_templates.yml
@@ -114,10 +114,36 @@
       failed_when:
         - start_result.rc != 0
         - "'already running' not in start_result.stderr"
+        - "'MAX' not in start_result.stderr"
       changed_when: start_result.rc == 0
       loop: "{{ templates_to_update }}"
       loop_control:
         label: "vm_id={{ item.vm_id }}"
+
+    # VMs that failed with "MAX X vcpus" couldn't start — exclude them from
+    # the wait/convert pipeline but keep the play running for the others.
+    - name: TEMPLATES UPDATE - BUILD started list (exclude CPU-limited VMs)
+      ansible.builtin.set_fact:
+        templates_started: >-
+          {{ templates_to_update | zip(start_result.results)
+                                 | rejectattr('1.stderr', 'search', 'MAX')
+                                 | map(attribute='0') | list }}
+        templates_skipped_cpu: >-
+          {{ templates_to_update | zip(start_result.results)
+                                 | selectattr('1.stderr', 'search', 'MAX')
+                                 | map(attribute='0') | list }}
+
+    - name: TEMPLATES UPDATE - WARN skipped templates (host CPU limit)
+      ansible.builtin.debug:
+        msg: |
+          WARNING: {{ templates_skipped_cpu | length }} template(s) skipped — host CPU limit:
+          {% for t in templates_skipped_cpu %}
+            - {{ t.vm_id }}  {{ t.vm_name }}  (spec: {{ t.spec }})
+          {% endfor %}
+          These templates require more vCPUs than this host provides.
+          They will NOT be converted. Run on a host with enough physical
+          CPUs, or lower vm_cores in the template playbook if intentional.
+      when: templates_skipped_cpu | length > 0
 
     #### #### #### wait until each VM auto-poweroffs (cloud-init done) #### #### ####
     # the loop is sequential per-vm, but since all started in parallel above,
@@ -130,7 +156,7 @@
       retries: 360                # safety cap : 360 × 5s = 30 min max per VM
       delay: 5
       until: stop_check.rc == 0
-      loop: "{{ templates_to_update }}"
+      loop: "{{ templates_started }}"
       loop_control:
         label: "vm_id={{ item.vm_id }}"
       changed_when: false
@@ -140,14 +166,14 @@
     - name: TEMPLATES UPDATE - DETACH bootstrap cicustom
       ansible.builtin.command:
         cmd: qm set {{ item.vm_id }} --delete cicustom
-      loop: "{{ templates_to_update }}"
+      loop: "{{ templates_started }}"
       loop_control:
         label: "vm_id={{ item.vm_id }}"
 
     - name: TEMPLATES UPDATE - RE-ATTACH apt-proxy cicustom (persistent for clones)
       ansible.builtin.command:
         cmd: qm set {{ item.vm_id }} --cicustom "vendor=local:snippets/range42-apt-proxy.yaml"
-      loop: "{{ templates_to_update }}"
+      loop: "{{ templates_started }}"
       loop_control:
         label: "vm_id={{ item.vm_id }}"
       when: (apt_proxy_url | default('')) | length > 0
@@ -155,7 +181,7 @@
     - name: TEMPLATES UPDATE - CONVERT VM to template
       ansible.builtin.command:
         cmd: qm template {{ item.vm_id }}
-      loop: "{{ templates_to_update }}"
+      loop: "{{ templates_started }}"
       loop_control:
         label: "vm_id={{ item.vm_id }}"
 
@@ -169,5 +195,8 @@
     - name: TEMPLATES UPDATE - DISPLAY DONE
       ansible.builtin.debug:
         msg: |
-          ✓ {{ templates | length }} templates updated and converted
+          ✓ {{ templates_started | length }} templates updated and converted
           ✓ apt-proxy cicustom re-attached (if apt_proxy_url set)
+          {% if templates_skipped_cpu | length > 0 %}
+          ⚠  {{ templates_skipped_cpu | length }} skipped (host CPU limit) — see warning above
+          {% endif %}

--- a/scenarios/blank_scenario_6_subnets/blank_scenario_6_subnets.delete_all.sh
+++ b/scenarios/blank_scenario_6_subnets/blank_scenario_6_subnets.delete_all.sh
@@ -37,9 +37,9 @@ echo ":: scenario VMs: ${SCENARIO_VM_IDS[*]}"
 echo ":: templates   : ${TEMPLATE_VM_IDS[*]}"
 echo ""
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/blank_scenario_6_subnets/blank_scenario_6_subnets.delete_all.sh
+++ b/scenarios/blank_scenario_6_subnets/blank_scenario_6_subnets.delete_all.sh
@@ -37,12 +37,14 @@ echo ":: scenario VMs: ${SCENARIO_VM_IDS[*]}"
 echo ":: templates   : ${TEMPLATE_VM_IDS[*]}"
 echo ""
 
-# the [WARNING] / jq parse error noise that may appear here comes from
-# proxmox_vm.list.to.jsons.sh (Ansible warnings leaking to stdout) — non-fatal,
-# the grep filter still catches the JSON lines properly. tracked separately.
-
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
 for ip in "${INFRASTRUCTURE_IP[@]}"; do
     echo ":: REMOVE SSH KEY FOR : $ip"

--- a/scenarios/blank_scenario_6_subnets/blank_scenario_6_subnets.delete_vms_only.sh
+++ b/scenarios/blank_scenario_6_subnets/blank_scenario_6_subnets.delete_vms_only.sh
@@ -28,9 +28,9 @@ echo ":: stopping and deleting scenario VMs (keeping templates)..."
 echo ":: scenario VMs: ${SCENARIO_VM_IDS[*]}"
 echo ""
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/blank_scenario_6_subnets/blank_scenario_6_subnets.delete_vms_only.sh
+++ b/scenarios/blank_scenario_6_subnets/blank_scenario_6_subnets.delete_vms_only.sh
@@ -28,8 +28,14 @@ echo ":: stopping and deleting scenario VMs (keeping templates)..."
 echo ":: scenario VMs: ${SCENARIO_VM_IDS[*]}"
 echo ""
 
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
 for ip in "${INFRASTRUCTURE_IP[@]}"; do
     echo ":: REMOVE SSH KEY FOR : $ip"

--- a/scenarios/blank_scenario_6_subnets/blank_scenario_6_subnets.reset.setup.sh
+++ b/scenarios/blank_scenario_6_subnets/blank_scenario_6_subnets.reset.setup.sh
@@ -19,9 +19,9 @@ ID_REGEX=$(printf '|%s' "${SCENARIO_VM_IDS[@]}" | sed 's/^|//')
 
 echo ":: stopping and deleting scenario VMs (vm_ids: ${SCENARIO_VM_IDS[*]})..."
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/blank_scenario_6_subnets/blank_scenario_6_subnets.reset.setup.sh
+++ b/scenarios/blank_scenario_6_subnets/blank_scenario_6_subnets.reset.setup.sh
@@ -19,8 +19,14 @@ ID_REGEX=$(printf '|%s' "${SCENARIO_VM_IDS[@]}" | sed 's/^|//')
 
 echo ":: stopping and deleting scenario VMs (vm_ids: ${SCENARIO_VM_IDS[*]})..."
 
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -E "\"vm_id\":($ID_REGEX)([^0-9]|\$)" | proxmox_vm.vm_id.delete.to.jsons.sh
 
 for ip in "${INFRASTRUCTURE_IP[@]}"; do
     echo ":: REMOVE SSH KEY FOR : $ip"

--- a/scenarios/debug_scenario_a/debug_scenario_a.delete_all.sh
+++ b/scenarios/debug_scenario_a/debug_scenario_a.delete_all.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
 
 INFRASTRUCTURE_IP=(
     "192.168.147.250" # dsa-vm-01

--- a/scenarios/debug_scenario_a/debug_scenario_a.delete_all.sh
+++ b/scenarios/debug_scenario_a/debug_scenario_a.delete_all.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/debug_scenario_a/debug_scenario_a.delete_vms_only.sh
+++ b/scenarios/debug_scenario_a/debug_scenario_a.delete_vms_only.sh
@@ -6,9 +6,9 @@
 
 echo ":: stopping and deleting VMs (keeping templates)..."
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/debug_scenario_a/debug_scenario_a.delete_vms_only.sh
+++ b/scenarios/debug_scenario_a/debug_scenario_a.delete_vms_only.sh
@@ -6,8 +6,14 @@
 
 echo ":: stopping and deleting VMs (keeping templates)..."
 
-proxmox_vm.list.to.jsons.sh | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.delete.to.jsons.sh
 
 INFRASTRUCTURE_IP=(
     "192.168.147.250" # dsa-vm-01

--- a/scenarios/debug_scenario_a/debug_scenario_a.reset.setup.sh
+++ b/scenarios/debug_scenario_a/debug_scenario_a.reset.setup.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
 
 INFRASTRUCTURE_IP=(
     "192.168.147.250" # dsa-vm-01

--- a/scenarios/debug_scenario_a/debug_scenario_a.reset.setup.sh
+++ b/scenarios/debug_scenario_a/debug_scenario_a.reset.setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/debug_scenario_b/debug_scenario_b.delete_all.sh
+++ b/scenarios/debug_scenario_b/debug_scenario_b.delete_all.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
 
 INFRASTRUCTURE_IP=(
     "192.168.148.250" # dsb-vm-01

--- a/scenarios/debug_scenario_b/debug_scenario_b.delete_all.sh
+++ b/scenarios/debug_scenario_b/debug_scenario_b.delete_all.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/debug_scenario_b/debug_scenario_b.delete_vms_only.sh
+++ b/scenarios/debug_scenario_b/debug_scenario_b.delete_vms_only.sh
@@ -6,9 +6,9 @@
 
 echo ":: stopping and deleting VMs (keeping templates)..."
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/debug_scenario_b/debug_scenario_b.delete_vms_only.sh
+++ b/scenarios/debug_scenario_b/debug_scenario_b.delete_vms_only.sh
@@ -6,8 +6,14 @@
 
 echo ":: stopping and deleting VMs (keeping templates)..."
 
-proxmox_vm.list.to.jsons.sh | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.delete.to.jsons.sh
 
 INFRASTRUCTURE_IP=(
     "192.168.148.250" # dsb-vm-01

--- a/scenarios/debug_scenario_b/debug_scenario_b.reset.setup.sh
+++ b/scenarios/debug_scenario_b/debug_scenario_b.reset.setup.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
 
 INFRASTRUCTURE_IP=(
     "192.168.148.250" # dsb-vm-01

--- a/scenarios/debug_scenario_b/debug_scenario_b.reset.setup.sh
+++ b/scenarios/debug_scenario_b/debug_scenario_b.reset.setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/demo_lab/demo_lab.delete_all.sh
+++ b/scenarios/demo_lab/demo_lab.delete_all.sh
@@ -1,8 +1,14 @@
 #!/bin/bash 
 
 
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
 
 
 ADMIN_INFRASTRUCTURE_IP=(

--- a/scenarios/demo_lab/demo_lab.delete_all.sh
+++ b/scenarios/demo_lab/demo_lab.delete_all.sh
@@ -1,9 +1,9 @@
 #!/bin/bash 
 
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/demo_lab/demo_lab.delete_vms_only.sh
+++ b/scenarios/demo_lab/demo_lab.delete_vms_only.sh
@@ -7,9 +7,9 @@
 
 echo ":: stopping and deleting VMs (keeping templates)..."
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi

--- a/scenarios/demo_lab/demo_lab.delete_vms_only.sh
+++ b/scenarios/demo_lab/demo_lab.delete_vms_only.sh
@@ -7,8 +7,14 @@
 
 echo ":: stopping and deleting VMs (keeping templates)..."
 
-proxmox_vm.list.to.jsons.sh | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | grep -vi "template-vm" | grep -vi '"vm_template":1' | proxmox_vm.vm_id.delete.to.jsons.sh
 
 INFRASTRUCTURE_IP=(
     "192.168.142.111" # testing-wazuh-client

--- a/scenarios/demo_lab/demo_lab.reset.setup.sh
+++ b/scenarios/demo_lab/demo_lab.reset.setup.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
-proxmox_vm.list.to.jsons.sh | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
+if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+    printf "output: %.200s\n" "$VM_LIST_JSON" >&2
+    exit 1
+fi
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.stop_force.to.jsons.sh
+echo "$VM_LIST_JSON" | jq -c | proxmox_vm.vm_id.delete.to.jsons.sh
 
 ADMIN_INFRASTRUCTURE_IP=(
     "192.168.142.111" # testing-wazuh-client

--- a/scenarios/demo_lab/demo_lab.reset.setup.sh
+++ b/scenarios/demo_lab/demo_lab.reset.setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1)
-if ! echo "$VM_LIST_JSON" | jq -e . >/dev/null 2>&1; then
-    echo "ERROR: proxmox_vm.list.to.jsons.sh returned invalid JSON — aborting" >&2
+VM_LIST_JSON=$(proxmox_vm.list.to.jsons.sh 2>&1 | grep '"vm_id":[0-9]')
+if [ -z "$VM_LIST_JSON" ]; then
+    echo "ERROR: proxmox_vm.list.to.jsons.sh returned no VM data (no vm_id lines) — aborting" >&2
     printf "output: %.200s\n" "$VM_LIST_JSON" >&2
     exit 1
 fi


### PR DESCRIPTION
WAVE_01 release. Merges 2 contributor PRs + 1 follow-up fix from integration testing.

### Merged contributor PRs (2)
#45, #47

### Follow-up fixes from integration testing
- fix(scenarios): replace fragile jq -e check with grep on vm_id across 20 .sh files (#47 follow-up)

### Integration test plan 
- [x] delete_vms_only / delete_all / reset.setup tested on debug_scenario_a/b and blank_scenario_2_subnets

Closes #49