### PR TITLE
fix(scenarios): parameterize cloud-init DNS instead of hardcoding 1.1.1.1

### DIFF
--- a/scenarios/blank_scenario_2_subnets/01_admin_infrastructure/stage_00/bs2_admin_deployer_api_backend.yml
+++ b/scenarios/blank_scenario_2_subnets/01_admin_infrastructure/stage_00/bs2_admin_deployer_api_backend.yml
@@ -85,7 +85,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/blank_scenario_2_subnets/01_admin_infrastructure/stage_00/bs2_admin_deployer_api_gateway.yml
+++ b/scenarios/blank_scenario_2_subnets/01_admin_infrastructure/stage_00/bs2_admin_deployer_api_gateway.yml
@@ -85,7 +85,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/blank_scenario_2_subnets/01_admin_infrastructure/stage_00/bs2_admin_deployer_ui.yml
+++ b/scenarios/blank_scenario_2_subnets/01_admin_infrastructure/stage_00/bs2_admin_deployer_ui.yml
@@ -85,7 +85,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/blank_scenario_2_subnets/01_admin_infrastructure/stage_00/bs2_admin_wazuh.yml
+++ b/scenarios/blank_scenario_2_subnets/01_admin_infrastructure/stage_00/bs2_admin_wazuh.yml
@@ -85,7 +85,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/00-template-vm-nano.yml
+++ b/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/00-template-vm-nano.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.201"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/01-template-vm-micro-01-2g-24g.yml
+++ b/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/01-template-vm-micro-01-2g-24g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.211"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/01-template-vm-micro-02-2g-24g.yml
+++ b/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/01-template-vm-micro-02-2g-24g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.212"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-01-4g-32g.yml
+++ b/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-01-4g-32g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.221"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-02-4g-32g.yml
+++ b/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-02-4g-32g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.222"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-04-4g-32g.yml
+++ b/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-04-4g-32g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.224"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-02-8g-64g.yml
+++ b/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-02-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.232"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-04-8g-64g.yml
+++ b/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-04-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.234"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-06-8g-64g.yml
+++ b/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-06-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.236"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-04-8g-64g.yml
+++ b/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-04-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.244"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-06-8g-64g.yml
+++ b/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-06-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.246"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-08-8g-64g.yml
+++ b/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-08-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.248"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/test_setup_templates.yml
+++ b/scenarios/blank_scenario_2_subnets/01_init_proxmox/templates/ubuntu_noble/test_setup_templates.yml
@@ -83,7 +83,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.55"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/blank_scenario_2_subnets/02_network_lab/stage_00/bs2_team_143_01.yml
+++ b/scenarios/blank_scenario_2_subnets/02_network_lab/stage_00/bs2_team_143_01.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_2_subnets/02_network_lab/stage_00/bs2_team_143_02.yml
+++ b/scenarios/blank_scenario_2_subnets/02_network_lab/stage_00/bs2_team_143_02.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_2_subnets/02_network_lab/stage_00/bs2_team_144_01.yml
+++ b/scenarios/blank_scenario_2_subnets/02_network_lab/stage_00/bs2_team_144_01.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_2_subnets/02_network_lab/stage_00/bs2_team_144_02.yml
+++ b/scenarios/blank_scenario_2_subnets/02_network_lab/stage_00/bs2_team_144_02.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_2_subnets/templates/ansible-vars.yml
+++ b/scenarios/blank_scenario_2_subnets/templates/ansible-vars.yml
@@ -33,3 +33,8 @@ default_admin_vm_ci_user: "alice"
 
 # student vm user
 default_trainee_vm_ci_user: "bob"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/blank_scenario_2_subnets/templates/vault-example.yml
+++ b/scenarios/blank_scenario_2_subnets/templates/vault-example.yml
@@ -63,3 +63,8 @@ WAZUH_PASSWORD: "REPLACE_ME"
 
 # deployer-cli known_hosts path (not really secret, but stored in vault historically)
 deployer_cli_user_ssh_known_hosts: "/home/your_deployer_cli_username/.ssh/known_hosts"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/blank_scenario_4_subnets/01_admin_infrastructure/stage_00/bs4_admin_deployer_api_backend.yml
+++ b/scenarios/blank_scenario_4_subnets/01_admin_infrastructure/stage_00/bs4_admin_deployer_api_backend.yml
@@ -85,7 +85,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/blank_scenario_4_subnets/01_admin_infrastructure/stage_00/bs4_admin_deployer_api_gateway.yml
+++ b/scenarios/blank_scenario_4_subnets/01_admin_infrastructure/stage_00/bs4_admin_deployer_api_gateway.yml
@@ -85,7 +85,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/blank_scenario_4_subnets/01_admin_infrastructure/stage_00/bs4_admin_deployer_ui.yml
+++ b/scenarios/blank_scenario_4_subnets/01_admin_infrastructure/stage_00/bs4_admin_deployer_ui.yml
@@ -85,7 +85,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/blank_scenario_4_subnets/01_admin_infrastructure/stage_00/bs4_admin_wazuh.yml
+++ b/scenarios/blank_scenario_4_subnets/01_admin_infrastructure/stage_00/bs4_admin_wazuh.yml
@@ -85,7 +85,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/00-template-vm-nano.yml
+++ b/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/00-template-vm-nano.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.201"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/01-template-vm-micro-01-2g-24g.yml
+++ b/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/01-template-vm-micro-01-2g-24g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.211"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/01-template-vm-micro-02-2g-24g.yml
+++ b/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/01-template-vm-micro-02-2g-24g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.212"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-01-4g-32g.yml
+++ b/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-01-4g-32g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.221"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-02-4g-32g.yml
+++ b/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-02-4g-32g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.222"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-04-4g-32g.yml
+++ b/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-04-4g-32g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.224"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-02-8g-64g.yml
+++ b/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-02-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.232"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-04-8g-64g.yml
+++ b/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-04-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.234"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-06-8g-64g.yml
+++ b/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-06-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.236"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-04-8g-64g.yml
+++ b/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-04-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.244"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-06-8g-64g.yml
+++ b/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-06-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.246"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-08-8g-64g.yml
+++ b/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-08-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.248"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/test_setup_templates.yml
+++ b/scenarios/blank_scenario_4_subnets/01_init_proxmox/templates/ubuntu_noble/test_setup_templates.yml
@@ -83,7 +83,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.55"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_143_01.yml
+++ b/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_143_01.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_143_02.yml
+++ b/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_143_02.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_143_03.yml
+++ b/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_143_03.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_143_04.yml
+++ b/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_143_04.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_144_01.yml
+++ b/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_144_01.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_144_02.yml
+++ b/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_144_02.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_144_03.yml
+++ b/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_144_03.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_144_04.yml
+++ b/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_144_04.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_145_01.yml
+++ b/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_145_01.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_145_02.yml
+++ b/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_145_02.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_145_03.yml
+++ b/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_145_03.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_145_04.yml
+++ b/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_145_04.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_146_01.yml
+++ b/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_146_01.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_146_02.yml
+++ b/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_146_02.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_146_03.yml
+++ b/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_146_03.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_146_04.yml
+++ b/scenarios/blank_scenario_4_subnets/02_network_lab/stage_00/bs4_team_146_04.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_4_subnets/templates/ansible-vars.yml
+++ b/scenarios/blank_scenario_4_subnets/templates/ansible-vars.yml
@@ -33,3 +33,8 @@ default_admin_vm_ci_user: "alice"
 
 # student vm user
 default_trainee_vm_ci_user: "bob"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/blank_scenario_4_subnets/templates/vault-example.yml
+++ b/scenarios/blank_scenario_4_subnets/templates/vault-example.yml
@@ -63,3 +63,8 @@ WAZUH_PASSWORD: "REPLACE_ME"
 
 # deployer-cli known_hosts path (not really secret, but stored in vault historically)
 deployer_cli_user_ssh_known_hosts: "/home/your_deployer_cli_username/.ssh/known_hosts"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/blank_scenario_6_subnets/01_admin_infrastructure/stage_00/bs6_admin_deployer_api_backend.yml
+++ b/scenarios/blank_scenario_6_subnets/01_admin_infrastructure/stage_00/bs6_admin_deployer_api_backend.yml
@@ -85,7 +85,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/blank_scenario_6_subnets/01_admin_infrastructure/stage_00/bs6_admin_deployer_api_gateway.yml
+++ b/scenarios/blank_scenario_6_subnets/01_admin_infrastructure/stage_00/bs6_admin_deployer_api_gateway.yml
@@ -85,7 +85,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/blank_scenario_6_subnets/01_admin_infrastructure/stage_00/bs6_admin_deployer_ui.yml
+++ b/scenarios/blank_scenario_6_subnets/01_admin_infrastructure/stage_00/bs6_admin_deployer_ui.yml
@@ -85,7 +85,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/blank_scenario_6_subnets/01_admin_infrastructure/stage_00/bs6_admin_wazuh.yml
+++ b/scenarios/blank_scenario_6_subnets/01_admin_infrastructure/stage_00/bs6_admin_wazuh.yml
@@ -85,7 +85,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/00-template-vm-nano.yml
+++ b/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/00-template-vm-nano.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.201"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/01-template-vm-micro-01-2g-24g.yml
+++ b/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/01-template-vm-micro-01-2g-24g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.211"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/01-template-vm-micro-02-2g-24g.yml
+++ b/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/01-template-vm-micro-02-2g-24g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.212"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-01-4g-32g.yml
+++ b/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-01-4g-32g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.221"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-02-4g-32g.yml
+++ b/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-02-4g-32g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.222"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-04-4g-32g.yml
+++ b/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-04-4g-32g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.224"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-02-8g-64g.yml
+++ b/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-02-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.232"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-04-8g-64g.yml
+++ b/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-04-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.234"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-06-8g-64g.yml
+++ b/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-06-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.236"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-04-8g-64g.yml
+++ b/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-04-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.244"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-06-8g-64g.yml
+++ b/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-06-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.246"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-08-8g-64g.yml
+++ b/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-08-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.248"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/test_setup_templates.yml
+++ b/scenarios/blank_scenario_6_subnets/01_init_proxmox/templates/ubuntu_noble/test_setup_templates.yml
@@ -83,7 +83,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.55"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_143_01.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_143_01.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_143_02.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_143_02.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_143_03.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_143_03.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_143_04.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_143_04.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_144_01.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_144_01.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_144_02.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_144_02.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_144_03.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_144_03.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_144_04.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_144_04.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_145_01.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_145_01.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_145_02.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_145_02.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_145_03.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_145_03.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_145_04.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_145_04.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_146_01.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_146_01.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_146_02.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_146_02.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_146_03.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_146_03.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_146_04.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_146_04.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_147_01.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_147_01.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_147_02.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_147_02.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_147_03.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_147_03.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_147_04.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_147_04.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_148_01.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_148_01.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_148_02.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_148_02.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_148_03.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_148_03.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_148_04.yml
+++ b/scenarios/blank_scenario_6_subnets/02_network_lab/stage_00/bs6_team_148_04.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/blank_scenario_6_subnets/templates/ansible-vars.yml
+++ b/scenarios/blank_scenario_6_subnets/templates/ansible-vars.yml
@@ -33,3 +33,8 @@ default_admin_vm_ci_user: "alice"
 
 # student vm user
 default_trainee_vm_ci_user: "bob"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/blank_scenario_6_subnets/templates/vault-example.yml
+++ b/scenarios/blank_scenario_6_subnets/templates/vault-example.yml
@@ -63,3 +63,8 @@ WAZUH_PASSWORD: "REPLACE_ME"
 
 # deployer-cli known_hosts path (not really secret, but stored in vault historically)
 deployer_cli_user_ssh_known_hosts: "/home/your_deployer_cli_username/.ssh/known_hosts"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/catalog_try/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-01-4g-32g.yml
+++ b/scenarios/catalog_try/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-01-4g-32g.yml
@@ -83,7 +83,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.221"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/catalog_try/02_catalog-try_infrastructure/stage_00/catalog_try_vm.yml
+++ b/scenarios/catalog_try/02_catalog-try_infrastructure/stage_00/catalog_try_vm.yml
@@ -81,7 +81,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/catalog_try/templates/ansible-vars.yml
+++ b/scenarios/catalog_try/templates/ansible-vars.yml
@@ -31,3 +31,8 @@ student_additionnal_keys_count: 0
 
 # admin vm user (not secret - password and ssh key are in vault)
 default_admin_vm_ci_user: "alice"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/catalog_try/templates/vault-example.yml
+++ b/scenarios/catalog_try/templates/vault-example.yml
@@ -43,3 +43,8 @@ default_admin_vm_ci_ssh_key: "ssh-ed25519 AAAA... alice CODENAME-SCENARIO"
 
 # operator-side known_hosts snapshot used by the wait-for-SSH task
 deployer_cli_user_ssh_known_hosts: "REPLACE_ME"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/debug_scenario_a/01_init_proxmox/templates/alpine/00-template-vm-alpine-nano.yml
+++ b/scenarios/debug_scenario_a/01_init_proxmox/templates/alpine/00-template-vm-alpine-nano.yml
@@ -80,7 +80,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.203"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/debug_scenario_a/01_init_proxmox/templates/debian/00-template-vm-debian-nano.yml
+++ b/scenarios/debug_scenario_a/01_init_proxmox/templates/debian/00-template-vm-debian-nano.yml
@@ -80,7 +80,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.202"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/debug_scenario_a/01_init_proxmox/templates/ubuntu_noble/00-template-vm-nano.yml
+++ b/scenarios/debug_scenario_a/01_init_proxmox/templates/ubuntu_noble/00-template-vm-nano.yml
@@ -80,7 +80,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.201"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/debug_scenario_a/02_network_lab/stage_00/dsa_vm_01.yml
+++ b/scenarios/debug_scenario_a/02_network_lab/stage_00/dsa_vm_01.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/debug_scenario_a/templates/ansible-vars.yml
+++ b/scenarios/debug_scenario_a/templates/ansible-vars.yml
@@ -33,3 +33,8 @@ default_admin_vm_ci_user: "alice"
 
 # student vm user
 default_trainee_vm_ci_user: "bob"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/debug_scenario_a/templates/vault-example.yml
+++ b/scenarios/debug_scenario_a/templates/vault-example.yml
@@ -63,3 +63,8 @@ WAZUH_PASSWORD: "REPLACE_ME"
 
 # deployer-cli known_hosts path (not really secret, but stored in vault historically)
 deployer_cli_user_ssh_known_hosts: "/home/your_deployer_cli_username/.ssh/known_hosts"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/debug_scenario_b/01_init_proxmox/templates/alpine/00-template-vm-alpine-nano.yml
+++ b/scenarios/debug_scenario_b/01_init_proxmox/templates/alpine/00-template-vm-alpine-nano.yml
@@ -80,7 +80,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.203"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/debug_scenario_b/01_init_proxmox/templates/debian/00-template-vm-debian-nano.yml
+++ b/scenarios/debug_scenario_b/01_init_proxmox/templates/debian/00-template-vm-debian-nano.yml
@@ -80,7 +80,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.202"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/debug_scenario_b/01_init_proxmox/templates/ubuntu_noble/00-template-vm-nano.yml
+++ b/scenarios/debug_scenario_b/01_init_proxmox/templates/ubuntu_noble/00-template-vm-nano.yml
@@ -80,7 +80,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.201"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/debug_scenario_b/02_network_lab/stage_00/dsb_vm_01.yml
+++ b/scenarios/debug_scenario_b/02_network_lab/stage_00/dsb_vm_01.yml
@@ -54,7 +54,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "{{ global_vm_ci_ip_gw }}"

--- a/scenarios/debug_scenario_b/templates/ansible-vars.yml
+++ b/scenarios/debug_scenario_b/templates/ansible-vars.yml
@@ -33,3 +33,8 @@ default_admin_vm_ci_user: "alice"
 
 # student vm user
 default_trainee_vm_ci_user: "bob"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/debug_scenario_b/templates/vault-example.yml
+++ b/scenarios/debug_scenario_b/templates/vault-example.yml
@@ -63,3 +63,8 @@ WAZUH_PASSWORD: "REPLACE_ME"
 
 # deployer-cli known_hosts path (not really secret, but stored in vault historically)
 deployer_cli_user_ssh_known_hosts: "/home/your_deployer_cli_username/.ssh/known_hosts"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/00-template-vm-nano.yml
+++ b/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/00-template-vm-nano.yml
@@ -83,7 +83,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.201"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/01-template-vm-micro-01-2g-24g.yml
+++ b/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/01-template-vm-micro-01-2g-24g.yml
@@ -83,7 +83,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.211"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/01-template-vm-micro-02-2g-24g.yml
+++ b/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/01-template-vm-micro-02-2g-24g.yml
@@ -83,7 +83,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.212"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-01-4g-32g.yml
+++ b/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-01-4g-32g.yml
@@ -83,7 +83,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.221"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-02-4g-32g.yml
+++ b/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-02-4g-32g.yml
@@ -83,7 +83,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.222"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-04-4g-32g.yml
+++ b/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/02-template-vm-small-04-4g-32g.yml
@@ -83,7 +83,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.224"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-02-8g-64g.yml
+++ b/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-02-8g-64g.yml
@@ -83,7 +83,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.232"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-04-8g-64g.yml
+++ b/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-04-8g-64g.yml
@@ -83,7 +83,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.234"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-06-8g-64g.yml
+++ b/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-06-8g-64g.yml
@@ -83,7 +83,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.236"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-04-8g-64g.yml
+++ b/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-04-8g-64g.yml
@@ -83,7 +83,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.244"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-06-8g-64g.yml
+++ b/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-06-8g-64g.yml
@@ -83,7 +83,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.246"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-08-8g-64g.yml
+++ b/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/04-template-vm-large-08-8g-64g.yml
@@ -83,7 +83,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.248"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/test_setup_templates.yml
+++ b/scenarios/demo_lab/01_init_proxmox/templates/ubuntu_noble/test_setup_templates.yml
@@ -83,7 +83,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_trainee_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_trainee_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.142.55"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/02_admin_infrastructure/stage_00/_testing/wazuh_client_01.yml
+++ b/scenarios/demo_lab/02_admin_infrastructure/stage_00/_testing/wazuh_client_01.yml
@@ -83,7 +83,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/02_admin_infrastructure/stage_00/builder_api_devkit.yml
+++ b/scenarios/demo_lab/02_admin_infrastructure/stage_00/builder_api_devkit.yml
@@ -85,7 +85,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/02_admin_infrastructure/stage_00/builder_docker_registry.yml
+++ b/scenarios/demo_lab/02_admin_infrastructure/stage_00/builder_docker_registry.yml
@@ -85,7 +85,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/02_admin_infrastructure/stage_00/deployer_api_backend.yml
+++ b/scenarios/demo_lab/02_admin_infrastructure/stage_00/deployer_api_backend.yml
@@ -85,7 +85,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/02_admin_infrastructure/stage_00/deployer_api_gateway.yml
+++ b/scenarios/demo_lab/02_admin_infrastructure/stage_00/deployer_api_gateway.yml
@@ -85,7 +85,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/02_admin_infrastructure/stage_00/deployer_ui.yml
+++ b/scenarios/demo_lab/02_admin_infrastructure/stage_00/deployer_ui.yml
@@ -85,7 +85,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/02_admin_infrastructure/stage_00/mon_wazuh.yml
+++ b/scenarios/demo_lab/02_admin_infrastructure/stage_00/mon_wazuh.yml
@@ -85,7 +85,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/demo_lab/03_student_infrastructure/stage_00/student_box_01.yml
+++ b/scenarios/demo_lab/03_student_infrastructure/stage_00/student_box_01.yml
@@ -77,7 +77,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.143.1"

--- a/scenarios/demo_lab/04_ctf_infrastructure/stage_00/vuln_box_00.yml
+++ b/scenarios/demo_lab/04_ctf_infrastructure/stage_00/vuln_box_00.yml
@@ -78,7 +78,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.144.1"

--- a/scenarios/demo_lab/04_ctf_infrastructure/stage_00/vuln_box_01.yml
+++ b/scenarios/demo_lab/04_ctf_infrastructure/stage_00/vuln_box_01.yml
@@ -78,7 +78,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.144.1"

--- a/scenarios/demo_lab/04_ctf_infrastructure/stage_00/vuln_box_02.yml
+++ b/scenarios/demo_lab/04_ctf_infrastructure/stage_00/vuln_box_02.yml
@@ -78,7 +78,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.144.1"

--- a/scenarios/demo_lab/04_ctf_infrastructure/stage_00/vuln_box_03.yml
+++ b/scenarios/demo_lab/04_ctf_infrastructure/stage_00/vuln_box_03.yml
@@ -78,7 +78,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.144.1"

--- a/scenarios/demo_lab/04_ctf_infrastructure/stage_00/vuln_box_04.yml
+++ b/scenarios/demo_lab/04_ctf_infrastructure/stage_00/vuln_box_04.yml
@@ -78,7 +78,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.144.1"

--- a/scenarios/demo_lab/templates/ansible-vars.yml
+++ b/scenarios/demo_lab/templates/ansible-vars.yml
@@ -33,3 +33,8 @@ default_admin_vm_ci_user: "alice"
 
 # student vm user
 default_trainee_vm_ci_user: "bob"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/demo_lab/templates/vault-example.yml
+++ b/scenarios/demo_lab/templates/vault-example.yml
@@ -63,3 +63,8 @@ WAZUH_PASSWORD: "REPLACE_ME"
 
 # deployer-cli known_hosts path (not really secret, but stored in vault historically)
 deployer_cli_user_ssh_known_hosts: "/home/your_deployer_cli_username/.ssh/known_hosts"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/dev_deployer_ui_lab/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-02-8g-64g.yml
+++ b/scenarios/dev_deployer_ui_lab/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-02-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.232"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/dev_deployer_ui_lab/02_dev_deployer_ui_lab_infrastructure/stage_00/dev_backend_vm.yml
+++ b/scenarios/dev_deployer_ui_lab/02_dev_deployer_ui_lab_infrastructure/stage_00/dev_backend_vm.yml
@@ -82,7 +82,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/dev_deployer_ui_lab/02_dev_deployer_ui_lab_infrastructure/stage_00/dev_deployer_ui_vm.yml
+++ b/scenarios/dev_deployer_ui_lab/02_dev_deployer_ui_lab_infrastructure/stage_00/dev_deployer_ui_vm.yml
@@ -82,7 +82,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/dev_deployer_ui_lab/02_dev_deployer_ui_lab_infrastructure/stage_00/dev_kong_vm.yml
+++ b/scenarios/dev_deployer_ui_lab/02_dev_deployer_ui_lab_infrastructure/stage_00/dev_kong_vm.yml
@@ -82,7 +82,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/dev_deployer_ui_lab/templates/ansible-vars.yml
+++ b/scenarios/dev_deployer_ui_lab/templates/ansible-vars.yml
@@ -32,3 +32,8 @@ student_additional_keys_count: 0
 
 # admin vm user (not secret - password and ssh key are in vault)
 default_admin_vm_ci_user: "alice"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/dev_deployer_ui_lab/templates/vault-example.yml
+++ b/scenarios/dev_deployer_ui_lab/templates/vault-example.yml
@@ -43,3 +43,8 @@ default_admin_vm_ci_ssh_key: "ssh-ed25519 AAAA... alice CODENAME-SCENARIO"
 
 # operator-side known_hosts snapshot used by the wait-for-SSH task
 deployer_cli_user_ssh_known_hosts: "REPLACE_ME"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/kunai_lab/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-02-8g-64g.yml
+++ b/scenarios/kunai_lab/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-02-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.232"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/kunai_lab/02_kunai_lab_infrastructure/stage_00/admin_trainer_kunai_vm.yml
+++ b/scenarios/kunai_lab/02_kunai_lab_infrastructure/stage_00/admin_trainer_kunai_vm.yml
@@ -81,7 +81,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/kunai_lab/02_kunai_lab_infrastructure/stage_00/student_kunai_01_vm.yml
+++ b/scenarios/kunai_lab/02_kunai_lab_infrastructure/stage_00/student_kunai_01_vm.yml
@@ -82,7 +82,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/kunai_lab/02_kunai_lab_infrastructure/stage_00/student_kunai_02_vm.yml
+++ b/scenarios/kunai_lab/02_kunai_lab_infrastructure/stage_00/student_kunai_02_vm.yml
@@ -82,7 +82,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/kunai_lab/02_kunai_lab_infrastructure/stage_00/student_kunai_03_vm.yml
+++ b/scenarios/kunai_lab/02_kunai_lab_infrastructure/stage_00/student_kunai_03_vm.yml
@@ -82,7 +82,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/kunai_lab/02_kunai_lab_infrastructure/stage_00/student_kunai_04_vm.yml
+++ b/scenarios/kunai_lab/02_kunai_lab_infrastructure/stage_00/student_kunai_04_vm.yml
@@ -82,7 +82,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/kunai_lab/02_kunai_lab_infrastructure/stage_00/student_kunai_05_vm.yml
+++ b/scenarios/kunai_lab/02_kunai_lab_infrastructure/stage_00/student_kunai_05_vm.yml
@@ -82,7 +82,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/kunai_lab/templates/ansible-vars.yml
+++ b/scenarios/kunai_lab/templates/ansible-vars.yml
@@ -35,3 +35,8 @@ student_additionnal_keys_count: 0
 # cloud-init user is alice on all 6 VMs (medium template default, project
 # convention - matches demo_lab and the blank scenarios)
 default_admin_vm_ci_user: "alice"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/kunai_lab/templates/vault-example.yml
+++ b/scenarios/kunai_lab/templates/vault-example.yml
@@ -43,3 +43,8 @@ default_admin_vm_ci_ssh_key: "ssh-ed25519 AAAA... alice CODENAME-SCENARIO"
 
 # operator-side known_hosts snapshot used by the wait-for-SSH task
 deployer_cli_user_ssh_known_hosts: "REPLACE_ME"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/misp_lab/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-02-8g-64g.yml
+++ b/scenarios/misp_lab/01_init_proxmox/templates/ubuntu_noble/03-template-vm-medium-02-8g-64g.yml
@@ -137,7 +137,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "192.168.140.232"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.140.1"

--- a/scenarios/misp_lab/02_misp_lab_infrastructure/stage_00/misp_lab_vm.yml
+++ b/scenarios/misp_lab/02_misp_lab_infrastructure/stage_00/misp_lab_vm.yml
@@ -81,7 +81,7 @@
         vm_ci_user: "{{ default_admin_vm_ci_user | default('alice') }}"
         vm_ci_password: "{{ default_admin_vm_ci_password | default('supersecret') }}"
         vm_ci_ssh_key: "{{ default_admin_vm_ci_ssh_key  }}"
-        vm_ci_dns_ips: "1.1.1.1"
+        vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"
         vm_ci_ip: "{{ global_vm_ci_ip }}"
         vm_ci_netmask: "24"
         vm_ci_ip_gw: "192.168.142.1"

--- a/scenarios/misp_lab/templates/ansible-vars.yml
+++ b/scenarios/misp_lab/templates/ansible-vars.yml
@@ -31,3 +31,8 @@ student_additionnal_keys_count: 0
 
 # admin vm user (not secret - password and ssh key are in vault)
 default_admin_vm_ci_user: "alice"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"

--- a/scenarios/misp_lab/templates/vault-example.yml
+++ b/scenarios/misp_lab/templates/vault-example.yml
@@ -43,3 +43,8 @@ default_admin_vm_ci_ssh_key: "ssh-ed25519 AAAA... alice CODENAME-SCENARIO"
 
 # operator-side known_hosts snapshot used by the wait-for-SSH task
 deployer_cli_user_ssh_known_hosts: "REPLACE_ME"
+
+#### CLOUD-INIT DNS ####
+# default resolver for lab VMs; range42-init.py substitutes the Proxmox node
+# resolver here at workspace creation. 1.1.1.1 is the portable fallback.
+default_vm_ci_dns_ips: "1.1.1.1"


### PR DESCRIPTION
Companion to range42/range42#221.

## Problem
Every scenario hardcoded `vm_ci_dns_ips: "1.1.1.1"`. On lab networks that firewall `1.1.1.1`, template first-boot warm-up can't resolve apt mirrors and `range42-context deploy` hangs at the cloud-init auto-poweroff wait.

## Change
`vm_ci_dns_ips: "{{ default_vm_ci_dns_ips | default('1.1.1.1') }}"` (same pattern as the adjacent `vm_ci_user`/`vm_ci_password` lines). The default is set by `range42-init.py` from the Proxmox node resolver; `1.1.1.1` remains the fallback.

144 scenario files on this base. (Note: `dev_ada` has ~36 newer scenarios + the render_assets.py generator also fixed there, since they don't exist on `dev` yet.)