### PR TITLE
feat: kunai_lab workshop scenario with bundles

### DIFF
--- a/bundles/core/software.install.kunai_official_workshop/README.md
+++ b/bundles/core/software.install.kunai_official_workshop/README.md
@@ -1,0 +1,20 @@
+# software.install.kunai_official_workshop (bundle)
+
+Thin bundle: invokes the catalog role `software.install.kunai_official_workshop`
+(`range42-catalog/02_ansible_layer/admin/roles/`) on a target group. All the logic
+lives in the role; this bundle only sets `hosts` + `become` and calls the role.
+
+## Caller vars
+
+- `KUNAI_TARGET_GROUP` (required) - the ansible group to target.
+- `KUNAI_VERSION`, `KUNAI_ARCH`, `KUNAI_OPERATOR_USER`, `KUNAI_PYKUNAI_VERSION`,
+  `KUNAI_MISP_LOCAL_ENABLE`, `KUNAI_MISP_URL`, `KUNAI_MISP_KEY` (optional - role
+  defaults apply otherwise).
+
+## Example call-site
+
+```yaml
+- import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/software.install.kunai_official_workshop/main.yml"
+  vars:
+    KUNAI_TARGET_GROUP: "r42_kunai_lab_students_group"
+```

--- a/bundles/core/software.install.kunai_official_workshop/main.yml
+++ b/bundles/core/software.install.kunai_official_workshop/main.yml
@@ -1,0 +1,26 @@
+---
+# ============================================================================
+# bundles/core/software.install.kunai_official_workshop/main.yml
+# ============================================================================
+# Thin bundle: installs the CIRCL Kunai OFFICIAL workshop toolchain on a target
+# group by invoking the catalog role `software.install.kunai_official_workshop`
+# (range42-catalog/02_ansible_layer/admin/roles/).
+#
+# REQUIRED caller vars:
+#   KUNAI_TARGET_GROUP   ansible group to target (e.g. r42_kunai_lab_students_group)
+#
+# OPTIONAL caller vars (role defaults apply otherwise):
+#   KUNAI_VERSION, KUNAI_ARCH, KUNAI_OPERATOR_USER, KUNAI_PYKUNAI_VERSION,
+#   KUNAI_MISP_LOCAL_ENABLE, KUNAI_MISP_URL, KUNAI_MISP_KEY
+#
+# Example call-site:
+#   - import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/software.install.kunai_official_workshop/main.yml"
+#     vars:
+#       KUNAI_TARGET_GROUP: "r42_kunai_lab_students_group"
+# ============================================================================
+
+- name: install kunai official workshop toolchain
+  hosts: "{{ KUNAI_TARGET_GROUP }}"
+  become: true
+  roles:
+    - software.install.kunai_official_workshop

--- a/bundles/core/software.install.warmup.dot_files/README.md
+++ b/bundles/core/software.install.warmup.dot_files/README.md
@@ -1,0 +1,11 @@
+# software.install.warmup.dot_files (bundle)
+
+Thin bundle: invokes the catalog role `software.install.warmup.dot_files` on a target group
+for a given user (oh-my-zsh + zshrc + login shell = zsh). The role is reused as-is
+(parameterized by `OPERATOR_USER`).
+
+Caller vars: `TARGET_GROUP`, `TARGET_USER` (required) ; `INSTALL_ZSH_DOTFILES` (def YES),
+`INSTALL_VIM_DOTFILES` (def NO), `APPLY_FOR_ROOT` (def NO).
+
+> Distinct from the API-driven `bundles/core/linux/ubuntu/install/dot-files/` (which is
+> `hosts: all`) : this one is group-targeted for scenario composition.

--- a/bundles/core/software.install.warmup.dot_files/README.md
+++ b/bundles/core/software.install.warmup.dot_files/README.md
@@ -4,8 +4,10 @@ Thin bundle: invokes the catalog role `software.install.warmup.dot_files` on a t
 for a given user (oh-my-zsh + zshrc + login shell = zsh). The role is reused as-is
 (parameterized by `OPERATOR_USER`).
 
-Caller vars: `TARGET_GROUP`, `TARGET_USER` (required) ; `INSTALL_ZSH_DOTFILES` (def YES),
-`INSTALL_VIM_DOTFILES` (def NO), `APPLY_FOR_ROOT` (def NO).
+Caller vars: `TARGET_GROUP`, `TARGET_USER` (required) ; `WARMUP_INSTALL_ZSH_DOTFILES` (def YES),
+`WARMUP_INSTALL_VIM_DOTFILES` (def NO), `WARMUP_APPLY_FOR_ROOT` (def NO). The optional knobs use a
+distinct `WARMUP_` prefix (routed through `_warmup_*` internal vars) so they never self-reference
+the role vars of the same name - which would trigger recursive templating.
 
 > Distinct from the API-driven `bundles/core/linux/ubuntu/install/dot-files/` (which is
 > `hosts: all`) : this one is group-targeted for scenario composition.

--- a/bundles/core/software.install.warmup.dot_files/main.yml
+++ b/bundles/core/software.install.warmup.dot_files/main.yml
@@ -9,17 +9,24 @@
 # REQUIRED caller vars:
 #   TARGET_GROUP     ansible group to target
 #   TARGET_USER      user whose dotfiles are deployed (-> role OPERATOR_USER)
-# OPTIONAL:
-#   INSTALL_ZSH_DOTFILES (def YES), INSTALL_VIM_DOTFILES (def NO), APPLY_FOR_ROOT (def NO)
+# OPTIONAL caller vars (public UPPERCASE knobs, routed through _warmup_* internal
+# vars so they never self-reference the role vars of the same name -> no recursive
+# templating ; same pattern as system-baseline-*):
+#   WARMUP_INSTALL_ZSH_DOTFILES (def YES), WARMUP_INSTALL_VIM_DOTFILES (def NO),
+#   WARMUP_APPLY_FOR_ROOT (def NO)
 # ============================================================================
 
 - name: install dotfiles (oh-my-zsh) for a user
   hosts: "{{ TARGET_GROUP }}"
   become: true
+  vars:
+    _warmup_zsh_dotfiles: "{{ WARMUP_INSTALL_ZSH_DOTFILES | default('YES') }}"
+    _warmup_vim_dotfiles: "{{ WARMUP_INSTALL_VIM_DOTFILES | default('NO') }}"
+    _warmup_apply_for_root: "{{ WARMUP_APPLY_FOR_ROOT | default('NO') }}"
   roles:
     - role: software.install.warmup.dot_files
       vars:
         OPERATOR_USER: "{{ TARGET_USER }}"
-        INSTALL_ZSH_DOTFILES: "{{ INSTALL_ZSH_DOTFILES | default('YES') }}"
-        INSTALL_VIM_DOTFILES: "{{ INSTALL_VIM_DOTFILES | default('NO') }}"
-        APPLY_FOR_ROOT: "{{ APPLY_FOR_ROOT | default('NO') }}"
+        INSTALL_ZSH_DOTFILES: "{{ _warmup_zsh_dotfiles }}"
+        INSTALL_VIM_DOTFILES: "{{ _warmup_vim_dotfiles }}"
+        APPLY_FOR_ROOT: "{{ _warmup_apply_for_root }}"

--- a/bundles/core/software.install.warmup.dot_files/main.yml
+++ b/bundles/core/software.install.warmup.dot_files/main.yml
@@ -1,0 +1,25 @@
+---
+# ============================================================================
+# bundles/core/software.install.warmup.dot_files/main.yml
+# ============================================================================
+# Thin bundle: deploy the dotfiles (oh-my-zsh + zshrc, sets the login shell to
+# zsh) for a given user on a target group, via the catalog role
+# `software.install.warmup.dot_files` (reused as-is, parameterized by OPERATOR_USER).
+#
+# REQUIRED caller vars:
+#   TARGET_GROUP     ansible group to target
+#   TARGET_USER      user whose dotfiles are deployed (-> role OPERATOR_USER)
+# OPTIONAL:
+#   INSTALL_ZSH_DOTFILES (def YES), INSTALL_VIM_DOTFILES (def NO), APPLY_FOR_ROOT (def NO)
+# ============================================================================
+
+- name: install dotfiles (oh-my-zsh) for a user
+  hosts: "{{ TARGET_GROUP }}"
+  become: true
+  roles:
+    - role: software.install.warmup.dot_files
+      vars:
+        OPERATOR_USER: "{{ TARGET_USER }}"
+        INSTALL_ZSH_DOTFILES: "{{ INSTALL_ZSH_DOTFILES | default('YES') }}"
+        INSTALL_VIM_DOTFILES: "{{ INSTALL_VIM_DOTFILES | default('NO') }}"
+        APPLY_FOR_ROOT: "{{ APPLY_FOR_ROOT | default('NO') }}"

--- a/bundles/core/systems.configure.add_user/README.md
+++ b/bundles/core/systems.configure.add_user/README.md
@@ -1,0 +1,10 @@
+# systems.configure.add_user (bundle)
+
+Thin, group-targeted bundle: invokes the catalog role `systems.configure.add_user` on
+`TARGET_GROUP` to create a user (home + shell + password, no chpasswd).
+
+Caller vars: `TARGET_GROUP`, `TARGET_USER`, `TARGET_PASSWORD` (required) ;
+`TARGET_SHELL_PATH`, `TARGET_UPDATE_PASSWORD` (`always`/`on_create`), `CHANGE_PWD_AT_LOGON` (optional).
+
+> Distinct from the API-driven `bundles/core/linux/ubuntu/configure/add-user/` (`hosts: all`) :
+> this one is group-targeted for scenario composition. Same underlying role.

--- a/bundles/core/systems.configure.add_user/main.yml
+++ b/bundles/core/systems.configure.add_user/main.yml
@@ -1,0 +1,23 @@
+---
+# ============================================================================
+# bundles/core/systems.configure.add_user/main.yml
+# ============================================================================
+# Thin bundle: create a user (home + shell + password) on a target group via the
+# catalog role `systems.configure.add_user`.
+#
+# (The existing bundles/core/linux/ubuntu/configure/add-user/ is `hosts: all` and
+#  API-driven ; this one is group-targeted for scenario composition. Same role.)
+#
+# REQUIRED caller vars:
+#   TARGET_GROUP     ansible group to target
+#   TARGET_USER      user to create
+#   TARGET_PASSWORD  password (plaintext ; hashed by the role)
+# OPTIONAL:
+#   TARGET_SHELL_PATH, TARGET_UPDATE_PASSWORD (always|on_create), CHANGE_PWD_AT_LOGON
+# ============================================================================
+
+- name: create a user
+  hosts: "{{ TARGET_GROUP }}"
+  become: true
+  roles:
+    - systems.configure.add_user

--- a/bundles/core/systems.configure.authorized_keys/README.md
+++ b/bundles/core/systems.configure.authorized_keys/README.md
@@ -1,0 +1,6 @@
+# systems.configure.authorized_keys (bundle)
+
+Thin bundle: invokes the catalog role `systems.configure.authorized_keys` on a target group.
+
+Caller vars: `TARGET_GROUP`, `TARGET_USER`, `AUTHORIZED_KEY` (required) ;
+`AUTHORIZED_KEY_STATE`, `AUTHORIZED_KEY_EXCLUSIVE` (optional).

--- a/bundles/core/systems.configure.authorized_keys/main.yml
+++ b/bundles/core/systems.configure.authorized_keys/main.yml
@@ -1,0 +1,20 @@
+---
+# ============================================================================
+# bundles/core/systems.configure.authorized_keys/main.yml
+# ============================================================================
+# Thin bundle: manage a public key in a user's authorized_keys via the catalog
+# role `systems.configure.authorized_keys`.
+#
+# REQUIRED caller vars:
+#   TARGET_GROUP     ansible group to target
+#   TARGET_USER      user whose authorized_keys is managed
+#   AUTHORIZED_KEY   the public key string
+# OPTIONAL:
+#   AUTHORIZED_KEY_STATE, AUTHORIZED_KEY_EXCLUSIVE
+# ============================================================================
+
+- name: configure authorized_keys for a user
+  hosts: "{{ TARGET_GROUP }}"
+  become: true
+  roles:
+    - systems.configure.authorized_keys

--- a/bundles/core/systems.configure.os_auto_updates/README.md
+++ b/bundles/core/systems.configure.os_auto_updates/README.md
@@ -1,0 +1,18 @@
+# systems.configure.os_auto_updates (bundle)
+
+Thin bundle: invokes the catalog role `systems.configure.os_auto_updates` on a target group to
+disable (default) or enable the OS background auto-updater (`apt-daily` timers + `unattended-upgrades`
+on Debian/Ubuntu). Run it EARLY in a baseline, before any `apt` task, so the auto-updater never holds
+the dpkg lock during provisioning (and stopping it releases a lock that is already held).
+
+Caller vars: `TARGET_GROUP` (required) ; `OS_AUTO_UPDATES_STATE` (def `disabled`, set `enabled` to
+restore). The role reads `OS_AUTO_UPDATES_STATE` directly from play/extra-vars scope - the bundle does
+not re-forward it (a role var of the same name would self-reference and trigger recursive templating).
+
+## Example call-site
+
+```yaml
+- import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/systems.configure.os_auto_updates/main.yml"
+  vars:
+    TARGET_GROUP: "r42_kunai_lab_students_group"
+```

--- a/bundles/core/systems.configure.os_auto_updates/main.yml
+++ b/bundles/core/systems.configure.os_auto_updates/main.yml
@@ -1,0 +1,26 @@
+---
+# ============================================================================
+# bundles/core/systems.configure.os_auto_updates/main.yml
+# ============================================================================
+# Thin bundle: disable (or enable) the OS background auto-updater on a target
+# group, via the catalog role `systems.configure.os_auto_updates`.
+#
+# Run this EARLY in a scenario baseline (before any apt task) so the auto-updater
+# never holds the dpkg lock during provisioning. Stopping the units also releases
+# a lock that is already held.
+#
+# REQUIRED caller vars:
+#   TARGET_GROUP           ansible group to target
+# OPTIONAL caller vars:
+#   OS_AUTO_UPDATES_STATE  (def "disabled" in the role ; set "enabled" to restore).
+#                          Passed via -e or the import vars: (global/play scope), the
+#                          role reads it directly - do NOT re-forward it here (a role
+#                          var of the same name would self-reference -> recursion).
+# ============================================================================
+
+- name: configure OS background auto-updates on a group
+  hosts: "{{ TARGET_GROUP }}"
+  become: true
+  gather_facts: true
+  roles:
+    - role: systems.configure.os_auto_updates

--- a/bundles/core/systems.configure.ssh_keypair/README.md
+++ b/bundles/core/systems.configure.ssh_keypair/README.md
@@ -1,0 +1,6 @@
+# systems.configure.ssh_keypair (bundle)
+
+Thin bundle: invokes the catalog role `systems.configure.ssh_keypair` on a target group.
+
+Caller vars: `TARGET_GROUP`, `TARGET_USER`, `SSH_KEYPAIR_PRIVATE_SRC` (required) ;
+`SSH_KEYPAIR_PUBLIC_SRC`, `SSH_KEYPAIR_NAME` (optional).

--- a/bundles/core/systems.configure.ssh_keypair/main.yml
+++ b/bundles/core/systems.configure.ssh_keypair/main.yml
@@ -1,0 +1,20 @@
+---
+# ============================================================================
+# bundles/core/systems.configure.ssh_keypair/main.yml
+# ============================================================================
+# Thin bundle: deploy an SSH keypair into a user's ~/.ssh via the catalog role
+# `systems.configure.ssh_keypair`.
+#
+# REQUIRED caller vars:
+#   TARGET_GROUP              ansible group to target
+#   TARGET_USER               user whose ~/.ssh receives the keypair
+#   SSH_KEYPAIR_PRIVATE_SRC   path on the controller to the private key
+# OPTIONAL:
+#   SSH_KEYPAIR_PUBLIC_SRC, SSH_KEYPAIR_NAME
+# ============================================================================
+
+- name: configure ssh keypair for a user
+  hosts: "{{ TARGET_GROUP }}"
+  become: true
+  roles:
+    - systems.configure.ssh_keypair

--- a/bundles/core/systems.configure.sudo/README.md
+++ b/bundles/core/systems.configure.sudo/README.md
@@ -1,0 +1,6 @@
+# systems.configure.sudo (bundle)
+
+Thin bundle: invokes the catalog role `systems.configure.sudo` on a target group.
+
+Caller vars: `TARGET_GROUP`, `TARGET_USER` (required) ; `SUDO_STATE` (present/absent),
+`SUDO_NOPASSWD` (bool) (optional).

--- a/bundles/core/systems.configure.sudo/main.yml
+++ b/bundles/core/systems.configure.sudo/main.yml
@@ -1,0 +1,19 @@
+---
+# ============================================================================
+# bundles/core/systems.configure.sudo/main.yml
+# ============================================================================
+# Thin bundle: grant/revoke sudo for a user via the catalog role
+# `systems.configure.sudo`.
+#
+# REQUIRED caller vars:
+#   TARGET_GROUP     ansible group to target
+#   TARGET_USER      user to grant/revoke sudo
+# OPTIONAL:
+#   SUDO_STATE (present|absent), SUDO_NOPASSWD (bool)
+# ============================================================================
+
+- name: configure sudo for a user
+  hosts: "{{ TARGET_GROUP }}"
+  become: true
+  roles:
+    - systems.configure.sudo

--- a/scenarios/kunai_lab/03_trainer_infrastructure/_main_stage_01.yml
+++ b/scenarios/kunai_lab/03_trainer_infrastructure/_main_stage_01.yml
@@ -11,3 +11,6 @@
 ##
 
 - import_playbook: ./stage_01-vm_configure/_baseline_trainer.yml
+
+# Phase 1B : trainer -> students SSH client config (after the trainer user + keypair)
+- import_playbook: ./stage_01-vm_configure/_finalize-trainer_ssh_config.yml

--- a/scenarios/kunai_lab/03_trainer_infrastructure/stage_01-vm_configure/_baseline_trainer.yml
+++ b/scenarios/kunai_lab/03_trainer_infrastructure/stage_01-vm_configure/_baseline_trainer.yml
@@ -1,6 +1,7 @@
 ##
 ## Baseline for r42_kunai_lab_trainer_group (Phase 1B : human sudo user)
 ##
+##   - os_auto_updates               : disable apt-daily + unattended-upgrades FIRST (frees the dpkg lock)
 ##   - system-baseline-docker-host   : packages + dotfiles (alice) + Docker + docker-compose
 ##   - network-baseline-ssh          : firewall opens port 22
 ##   - tailscale-on-group            : optional (gated INSTALL_TAILSCALE, default NO)
@@ -16,6 +17,11 @@
 ## alice stays the DEPLOY user (ansible connection) ; trainer is the human account.
 ## The trainer -> student SSH config is deployed by _finalize-trainer_ssh_config.yml.
 ##
+
+## --- disable OS background auto-updates FIRST (before any apt task frees the dpkg lock) ---
+- import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/systems.configure.os_auto_updates/main.yml"
+  vars:
+    TARGET_GROUP: "r42_kunai_lab_trainer_group"
 
 - import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/system-baseline-docker-host/main.yml"
   vars:

--- a/scenarios/kunai_lab/03_trainer_infrastructure/stage_01-vm_configure/_baseline_trainer.yml
+++ b/scenarios/kunai_lab/03_trainer_infrastructure/stage_01-vm_configure/_baseline_trainer.yml
@@ -1,12 +1,20 @@
 ##
-## Baseline for r42_kunai_lab_trainer_group :
-##   - system-baseline-docker-host    : packages + dotfiles + Docker + docker-compose
-##                                      (kunai needs UTILS_JSON + UTILS_NETWORK on top of the
-##                                      docker-host profile defaults, hence the 2 overrides)
-##   - network-baseline-ssh           : firewall opens port 22
-##   - tailscale-on-group             : optional tailscale install (gated by INSTALL_TAILSCALE,
-##                                      default NO for kunai_lab per manifest/feature_flags.yml)
-##   - gitclone-kunai-repository      : clone the 5 kunai-project repos into /home/alice/kunai-project/
+## Baseline for r42_kunai_lab_trainer_group (Phase 1B : human sudo user)
+##
+##   - system-baseline-docker-host   : packages + dotfiles (alice) + Docker + docker-compose
+##   - network-baseline-ssh          : firewall opens port 22
+##   - tailscale-on-group            : optional (gated INSTALL_TAILSCALE, default NO)
+##   - compute-creds                 : load the vault, set trainer creds + private-key path (facts)
+##   - human user `trainer`          : add_user + authorized_keys (bob base, INBOUND access) + sudo NOPASSWD + oh-my-zsh
+##                                     (the OUTBOUND trainer->student key is a passphrase-less
+##                                      trainer-student-access key generated on this VM by
+##                                      _finalize-trainer_ssh_config.yml ; pushed to students by
+##                                      _finalize-trainer_student_access.yml)
+##   - gitclone-kunai-repository     : clone the 5 kunai repos into the TRAINER home
+##   - software.install.kunai_official_workshop : toolchain for the TRAINER (always installed - core of the lab)
+##
+## alice stays the DEPLOY user (ansible connection) ; trainer is the human account.
+## The trainer -> student SSH config is deployed by _finalize-trainer_ssh_config.yml.
 ##
 
 - import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/system-baseline-docker-host/main.yml"
@@ -26,6 +34,61 @@
     tailscale_hostnames:
       - "admin-trainer-kunai"
 
+## --- Phase 1B : compute trainer creds (loads the vault, sets facts) ---
+- name: kunai_lab - compute human-user creds (trainer VM)
+  hosts: r42_kunai_lab_trainer_group
+  gather_facts: false
+  vars_files:
+    - "{{ lookup('env', 'RANGE42_ACTIVE_CONFIG_DIR') }}/secrets/default_vault.yml"
+  tasks:
+    - name: assert the trainer (bob base) key is available in the vault
+      ansible.builtin.assert:
+        that:
+          - ssh_key_student_user_pub_key is defined
+          - ssh_key_student_user_pub_key | length > 0
+          - default_trainee_vm_ci_password is defined
+          - default_trainee_vm_ci_password | length > 0
+        fail_msg: "missing vault var (ssh_key_student_user_pub_key or default_trainee_vm_ci_password) - the wizard must have generated the bob base key + the trainee password"
+
+    - name: set trainer creds (derived password + bob base pubkey for INBOUND access)
+      ansible.builtin.set_fact:
+        _kunai_trainer_pubkey: "{{ ssh_key_student_user_pub_key }}"
+        _kunai_trainer_password: "{{ TRAINER_PASSWORD | default((ssh_key_student_user_pub_key ~ default_trainee_vm_ci_password) | hash('sha256'), true) }}"
+      no_log: true
+
+## --- human user `trainer` (keypair to SSH out + sudo NOPASSWD + oh-my-zsh) ---
+- import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/systems.configure.add_user/main.yml"
+  vars:
+    TARGET_GROUP: "r42_kunai_lab_trainer_group"
+    TARGET_USER: "trainer"
+    TARGET_PASSWORD: "{{ _kunai_trainer_password }}"
+    TARGET_SHELL_PATH: "/usr/bin/zsh"
+    TARGET_UPDATE_PASSWORD: "always"
+
+- import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/systems.configure.authorized_keys/main.yml"
+  vars:
+    TARGET_GROUP: "r42_kunai_lab_trainer_group"
+    TARGET_USER: "trainer"
+    AUTHORIZED_KEY: "{{ _kunai_trainer_pubkey }}"
+
+- import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/systems.configure.sudo/main.yml"
+  vars:
+    TARGET_GROUP: "r42_kunai_lab_trainer_group"
+    TARGET_USER: "trainer"
+    SUDO_NOPASSWD: true
+
+- import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/software.install.warmup.dot_files/main.yml"
+  vars:
+    TARGET_GROUP: "r42_kunai_lab_trainer_group"
+    TARGET_USER: "trainer"
+
+## --- repos + toolchain, repointed to the TRAINER human user ---
 - import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/gitclone-kunai-repository/main.yml"
   vars:
     GITCLONE_KUNAI_TARGET_GROUP: "r42_kunai_lab_trainer_group"
+    GITCLONE_KUNAI_OPERATOR_USER: "trainer"
+
+- import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/software.install.kunai_official_workshop/main.yml"
+  vars:
+    KUNAI_TARGET_GROUP: "r42_kunai_lab_trainer_group"
+    KUNAI_OPERATOR_USER: "trainer"

--- a/scenarios/kunai_lab/03_trainer_infrastructure/stage_01-vm_configure/_baseline_trainer.yml
+++ b/scenarios/kunai_lab/03_trainer_infrastructure/stage_01-vm_configure/_baseline_trainer.yml
@@ -87,6 +87,8 @@
   vars:
     TARGET_GROUP: "r42_kunai_lab_trainer_group"
     TARGET_USER: "trainer"
+    WARMUP_INSTALL_VIM_DOTFILES: "YES"   # vimrc for trainer + root
+    WARMUP_APPLY_FOR_ROOT: "YES"         # zsh + oh-my-zsh + vimrc for root too
 
 ## --- repos + toolchain, repointed to the TRAINER human user ---
 - import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/gitclone-kunai-repository/main.yml"

--- a/scenarios/kunai_lab/03_trainer_infrastructure/stage_01-vm_configure/_finalize-trainer_ssh_config.yml
+++ b/scenarios/kunai_lab/03_trainer_infrastructure/stage_01-vm_configure/_finalize-trainer_ssh_config.yml
@@ -1,0 +1,58 @@
+---
+##
+## kunai_lab - trainer SSH setup (on the trainer VM) :
+##   1. generate a PASSPHRASE-LESS `trainer-student-access` key (outbound only, trainer -> students).
+##      The private key stays ONLY on the trainer VM (never on students -> a student cannot use it to
+##      hop to other VMs).
+##   2. deploy ~trainer/.ssh/config so `ssh student-kunai-0X` uses that key (no passphrase -> no agent
+##      needed, ssh reads the IdentityFile directly).
+## The pubkey is pushed to the students' `trainer` authorized_keys by
+## _finalize-trainer_student_access.yml (cross-tier, after all stage_01).
+## Student targets mirror manifest/scenario_vms.json (student-kunai-01..05 / .105-.109).
+##
+
+- name: kunai_lab - trainer SSH setup (key + client config)
+  hosts: r42_kunai_lab_trainer_group
+  gather_facts: false
+  become: true
+  vars:
+    _kunai_students:
+      - { name: "student-kunai-01", ip: "192.168.142.105" }
+      - { name: "student-kunai-02", ip: "192.168.142.106" }
+      - { name: "student-kunai-03", ip: "192.168.142.107" }
+      - { name: "student-kunai-04", ip: "192.168.142.108" }
+      - { name: "student-kunai-05", ip: "192.168.142.109" }
+  tasks:
+    - name: ensure ~trainer/.ssh exists
+      ansible.builtin.file:
+        path: /home/trainer/.ssh
+        state: directory
+        owner: trainer
+        group: trainer
+        mode: "0700"
+
+    - name: generate the passphrase-less trainer-student-access key (outbound to students)
+      community.crypto.openssh_keypair:
+        path: /home/trainer/.ssh/trainer-student-access
+        type: ed25519
+        comment: "trainer-student-access kunai_lab"
+        mode: "0600"
+        regenerate: never
+      become_user: trainer
+
+    - name: deploy ~trainer/.ssh/config (ssh student-kunai-0X)
+      ansible.builtin.copy:
+        dest: /home/trainer/.ssh/config
+        owner: trainer
+        group: trainer
+        mode: "0600"
+        content: |
+          # range42 kunai_lab - trainer -> students. Managed by ansible, do not edit.
+          {% for s in _kunai_students %}
+          Host {{ s.name }}
+              HostName {{ s.ip }}
+              User trainer
+              IdentityFile ~/.ssh/trainer-student-access
+              StrictHostKeyChecking accept-new
+
+          {% endfor %}

--- a/scenarios/kunai_lab/04_student_infrastructure/stage_01-vm_configure/_baseline_student.yml
+++ b/scenarios/kunai_lab/04_student_infrastructure/stage_01-vm_configure/_baseline_student.yml
@@ -1,6 +1,7 @@
 ##
 ## Baseline for r42_kunai_lab_students_group (Phase 1B : human sudo users)
 ##
+##   - os_auto_updates               : disable apt-daily + unattended-upgrades FIRST (frees the dpkg lock)
 ##   - system-baseline-docker-host   : packages + dotfiles (alice) + Docker + docker-compose
 ##   - network-baseline-ssh          : firewall opens port 22
 ##   - tailscale-on-group            : optional (gated INSTALL_TAILSCALE, default NO)
@@ -14,6 +15,11 @@
 ##
 ## alice stays the DEPLOY user (ansible connection) ; student/trainer are the human accounts.
 ##
+
+## --- disable OS background auto-updates FIRST (before any apt task frees the dpkg lock) ---
+- import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/systems.configure.os_auto_updates/main.yml"
+  vars:
+    TARGET_GROUP: "r42_kunai_lab_students_group"
 
 - import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/system-baseline-docker-host/main.yml"
   vars:

--- a/scenarios/kunai_lab/04_student_infrastructure/stage_01-vm_configure/_baseline_student.yml
+++ b/scenarios/kunai_lab/04_student_infrastructure/stage_01-vm_configure/_baseline_student.yml
@@ -91,6 +91,8 @@
   vars:
     TARGET_GROUP: "r42_kunai_lab_students_group"
     TARGET_USER: "student"
+    WARMUP_INSTALL_VIM_DOTFILES: "YES"   # vimrc for student + root
+    WARMUP_APPLY_FOR_ROOT: "YES"         # zsh + oh-my-zsh + vimrc for root too (applied once per VM here)
 
 ## --- human user `trainer` on the student VMs (SSH-in from the trainer VM) ---
 - import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/systems.configure.add_user/main.yml"
@@ -111,6 +113,7 @@
   vars:
     TARGET_GROUP: "r42_kunai_lab_students_group"
     TARGET_USER: "trainer"
+    WARMUP_INSTALL_VIM_DOTFILES: "YES"   # vimrc for the trainer user (root already handled by the student import above)
 # NB: the trainer's authorized_keys on the student VMs (the trainer-student-access pubkey) is added by
 #     _finalize-trainer_student_access.yml (cross-tier), after that key is generated on the trainer VM.
 

--- a/scenarios/kunai_lab/04_student_infrastructure/stage_01-vm_configure/_baseline_student.yml
+++ b/scenarios/kunai_lab/04_student_infrastructure/stage_01-vm_configure/_baseline_student.yml
@@ -1,12 +1,18 @@
 ##
-## Baseline for r42_kunai_lab_students_group :
-##   - system-baseline-docker-host    : packages + dotfiles + Docker + docker-compose
-##                                      (kunai needs UTILS_JSON + UTILS_NETWORK on top of the
-##                                      docker-host profile defaults, hence the 2 overrides)
-##   - network-baseline-ssh           : firewall opens port 22
-##   - tailscale-on-group             : optional tailscale install (gated by INSTALL_TAILSCALE,
-##                                      default NO for kunai_lab per manifest/feature_flags.yml)
-##   - gitclone-kunai-repository      : clone the 5 kunai-project repos into /home/alice/kunai-project/
+## Baseline for r42_kunai_lab_students_group (Phase 1B : human sudo users)
+##
+##   - system-baseline-docker-host   : packages + dotfiles (alice) + Docker + docker-compose
+##   - network-baseline-ssh          : firewall opens port 22
+##   - tailscale-on-group            : optional (gated INSTALL_TAILSCALE, default NO)
+##   - compute-creds                 : load the vault, set per-host student + trainer creds (facts)
+##   - human user `student`          : add_user + authorized_keys (per-VM unique bob_N) + sudo NOPASSWD + oh-my-zsh
+##   - human user `trainer`          : add_user + sudo NOPASSWD (present here so the trainer can SSH in).
+##                                     Its authorized_keys (the trainer-student-access pubkey) is added by
+##                                     _finalize-trainer_student_access.yml (cross-tier, after key gen).
+##   - gitclone-kunai-repository     : clone the 5 kunai repos into the STUDENT home
+##   - software.install.kunai_official_workshop : toolchain for the STUDENT (always installed - core of the lab)
+##
+## alice stays the DEPLOY user (ansible connection) ; student/trainer are the human accounts.
 ##
 
 - import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/system-baseline-docker-host/main.yml"
@@ -30,6 +36,80 @@
       - "student-kunai-04"
       - "student-kunai-05"
 
+## --- Phase 1B : compute per-host human-user creds (loads the vault, sets facts) ---
+- name: kunai_lab - compute human-user creds (student VMs)
+  hosts: r42_kunai_lab_students_group
+  gather_facts: false
+  vars_files:
+    - "{{ lookup('env', 'RANGE42_ACTIVE_CONFIG_DIR') }}/secrets/default_vault.yml"
+  tasks:
+    - name: assert the per-VM student key is available in the vault
+      ansible.builtin.assert:
+        that:
+          - student_key_index is defined
+          - vars['ssh_key_student_user_extra_' ~ student_key_index ~ '_pub_key'] is defined
+          - (vars['ssh_key_student_user_extra_' ~ student_key_index ~ '_pub_key']) | length > 0
+          - default_trainee_vm_ci_password is defined
+          - default_trainee_vm_ci_password | length > 0
+        fail_msg: "missing vault var (per-VM student key or default_trainee_vm_ci_password) - ensure student_additional_keys_count >= number of student VMs, student_key_index is set per host, and the vault holds the trainee password"
+
+    - name: set per-host student + trainer creds (derived unique password, per-VM key)
+      ansible.builtin.set_fact:
+        _kunai_student_pubkey: "{{ vars['ssh_key_student_user_extra_' ~ student_key_index ~ '_pub_key'] }}"
+        _kunai_student_password: "{{ STUDENT_PASSWORD | default((vars['ssh_key_student_user_extra_' ~ student_key_index ~ '_pub_key'] ~ default_trainee_vm_ci_password) | hash('sha256'), true) }}"
+        _kunai_trainer_password: "{{ TRAINER_PASSWORD | default((ssh_key_student_user_pub_key ~ default_trainee_vm_ci_password) | hash('sha256'), true) }}"
+      no_log: true
+
+## --- human user `student` (per-VM unique key + password, sudo NOPASSWD, oh-my-zsh) ---
+- import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/systems.configure.add_user/main.yml"
+  vars:
+    TARGET_GROUP: "r42_kunai_lab_students_group"
+    TARGET_USER: "student"
+    TARGET_PASSWORD: "{{ _kunai_student_password }}"
+    TARGET_SHELL_PATH: "/usr/bin/zsh"
+    TARGET_UPDATE_PASSWORD: "always"
+
+- import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/systems.configure.authorized_keys/main.yml"
+  vars:
+    TARGET_GROUP: "r42_kunai_lab_students_group"
+    TARGET_USER: "student"
+    AUTHORIZED_KEY: "{{ _kunai_student_pubkey }}"
+
+- import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/systems.configure.sudo/main.yml"
+  vars:
+    TARGET_GROUP: "r42_kunai_lab_students_group"
+    TARGET_USER: "student"
+    SUDO_NOPASSWD: true
+
+- import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/software.install.warmup.dot_files/main.yml"
+  vars:
+    TARGET_GROUP: "r42_kunai_lab_students_group"
+    TARGET_USER: "student"
+
+## --- human user `trainer` on the student VMs (SSH-in from the trainer VM) ---
+- import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/systems.configure.add_user/main.yml"
+  vars:
+    TARGET_GROUP: "r42_kunai_lab_students_group"
+    TARGET_USER: "trainer"
+    TARGET_PASSWORD: "{{ _kunai_trainer_password }}"
+    TARGET_SHELL_PATH: "/usr/bin/zsh"
+    TARGET_UPDATE_PASSWORD: "always"
+
+- import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/systems.configure.sudo/main.yml"
+  vars:
+    TARGET_GROUP: "r42_kunai_lab_students_group"
+    TARGET_USER: "trainer"
+    SUDO_NOPASSWD: true
+# NB: the trainer's authorized_keys on the student VMs (the trainer-student-access pubkey) is added by
+#     _finalize-trainer_student_access.yml (cross-tier), after that key is generated on the trainer VM.
+
+## --- repos + toolchain, repointed to the STUDENT human user ---
 - import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/gitclone-kunai-repository/main.yml"
   vars:
     GITCLONE_KUNAI_TARGET_GROUP: "r42_kunai_lab_students_group"
+    GITCLONE_KUNAI_OPERATOR_USER: "student"
+
+- import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/software.install.kunai_official_workshop/main.yml"
+  vars:
+    KUNAI_TARGET_GROUP: "r42_kunai_lab_students_group"
+    KUNAI_OPERATOR_USER: "student"

--- a/scenarios/kunai_lab/04_student_infrastructure/stage_01-vm_configure/_baseline_student.yml
+++ b/scenarios/kunai_lab/04_student_infrastructure/stage_01-vm_configure/_baseline_student.yml
@@ -6,7 +6,7 @@
 ##   - tailscale-on-group            : optional (gated INSTALL_TAILSCALE, default NO)
 ##   - compute-creds                 : load the vault, set per-host student + trainer creds (facts)
 ##   - human user `student`          : add_user + authorized_keys (per-VM unique bob_N) + sudo NOPASSWD + oh-my-zsh
-##   - human user `trainer`          : add_user + sudo NOPASSWD (present here so the trainer can SSH in).
+##   - human user `trainer`          : add_user + sudo NOPASSWD + oh-my-zsh (present here so the trainer can SSH in).
 ##                                     Its authorized_keys (the trainer-student-access pubkey) is added by
 ##                                     _finalize-trainer_student_access.yml (cross-tier, after key gen).
 ##   - gitclone-kunai-repository     : clone the 5 kunai repos into the STUDENT home
@@ -100,6 +100,11 @@
     TARGET_GROUP: "r42_kunai_lab_students_group"
     TARGET_USER: "trainer"
     SUDO_NOPASSWD: true
+
+- import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/software.install.warmup.dot_files/main.yml"
+  vars:
+    TARGET_GROUP: "r42_kunai_lab_students_group"
+    TARGET_USER: "trainer"
 # NB: the trainer's authorized_keys on the student VMs (the trainer-student-access pubkey) is added by
 #     _finalize-trainer_student_access.yml (cross-tier), after that key is generated on the trainer VM.
 

--- a/scenarios/kunai_lab/README.md
+++ b/scenarios/kunai_lab/README.md
@@ -2,7 +2,7 @@
 
 Multi-VM training scenario that delivers 6 Ubuntu LTS hosts (1 trainer + 5 students) pre-provisioned with the Docker baseline plus the [kunai-project](https://github.com/kunai-project) ecosystem repositories pre-cloned in the operator home. Designed to run the kunai workshops out of the box.
 
-The 6 VMs are cloned from the project standard medium Ubuntu noble template (VMID 9232 - 2cpu / 8gb RAM / 64gb disk) onto the shared services bridge `vmbr142`. Single in-VM user `alice` on every VM (project convention - matches demo_lab and the blank scenarios). The kunai-project repos are pre-cloned into `/home/alice/kunai-project/` on the trainer and on each student VM.
+The 6 VMs are cloned from the project standard medium Ubuntu noble template (VMID 9232 - 2cpu / 8gb RAM / 64gb disk) onto the shared services bridge `vmbr142`. **User model** : `alice` is the deploy/transport user (ansible connects as alice, unchanged) ; on top, each VM gets a **human sudo account** - `trainer` on the trainer VM, `student` on each student VM (per-VM unique credentials). The kunai-project repos + toolchain are installed in the **human user's** home (`/home/trainer/`, `/home/student/`). See the [User model](#user-model-phase-1b) section.
 
 ## Scope
 
@@ -13,7 +13,8 @@ The 6 VMs are cloned from the project standard medium Ubuntu noble template (VMI
 - Basic utilities : curl, git, jq, vim, network diagnostic tools
 - UFW firewall enabled with port 22 open
 - NTP time sync
-- 5 kunai-project repositories cloned into `/home/alice/kunai-project/` on every VM (trainer + 5 students) :
+- human sudo accounts on every VM : `trainer` (trainer VM) + `student` (each student VM), per-VM unique creds
+- 5 kunai-project repositories cloned into the human user's home (`/home/trainer/kunai-project/` on the trainer, `/home/student/kunai-project/` on each student) :
   - `workshops`
   - `kunai-doc`
   - `kunai-build-docker`
@@ -27,6 +28,25 @@ The 6 VMs are cloned from the project standard medium Ubuntu noble template (VMI
 - Application-level firewall openings (kept closed at scenario time on purpose)
 
 Once kunai_lab is deployed, the trainer walks through the workshops with the students from `r42.admin-trainer-kunai`, and students follow along on their own `r42.student-kunai-NN` VM with the same repo layout.
+
+## User model (Phase 1B)
+
+Three roles, cleanly separated :
+
+- **`alice`** - the DEPLOY user. Ansible connects (SSH transport) as alice on every VM, as during provisioning. Unchanged. Not a workshop account.
+- **`student`** - the human sudo account on each student VM. Same username on all 5 VMs, but **UNIQUE credentials per VM** : a per-VM SSH key (`bob_1..5`, one per VM) + a derived password. Students log in with their key (handed off out-of-band by the trainer) or the password.
+- **`trainer`** - the human sudo account. Present on the trainer VM AND on every student VM (so the trainer can `ssh student-kunai-0X` to reach any student). On the trainer VM a **passphrase-less `trainer-student-access` key** is generated (stays ONLY on the trainer VM) ; its pubkey is authorized on the students' `trainer` account. `~trainer/.ssh/config` maps `student-kunai-01..05` to their IPs.
+
+**Credentials reference** : every created human account + its derived password + the SSH key it uses are recorded at deploy in `<workspace>/secrets/created_users.json`. The keys themselves live under `<workspace>/ssh_keys/student_keys/`.
+
+**Security notes (intentional)** :
+- `student` and `trainer` both have **NOPASSWD sudo** (passwordless root) - intended for a training lab.
+- the `trainer-student-access` private key lives **only on the trainer VM**, never on a student VM - a student (even root on their own VM) cannot use it to hop to other VMs.
+- passwords are DERIVED from the per-VM public key + a secret vault salt : unique per VM, non-predictable. Override at deploy with `-e STUDENT_PASSWORD=...` (common to all students) / `-e TRAINER_PASSWORD=...`.
+
+> Enabling this tier makes the wizard generate the per-student keys, so it needs a workspace **re-init** (not just a redeploy) the first time. A re-init rotates the keys, so re-deploy afterwards.
+
+> If a student VM is **rebuilt** (new SSH host key), the trainer's `~/.ssh/config` uses `StrictHostKeyChecking accept-new`, which accepts unknown hosts but rejects a *changed* key. Clear the stale entry on the trainer VM before reconnecting : `ssh-keygen -R <student-ip>` (e.g. `ssh-keygen -R 192.168.142.105`).
 
 ## Network architecture
 
@@ -56,7 +76,7 @@ No dedicated subnet. The 6 VMs live on `vmbr142`, the shared services bridge. Th
 | student-kunai-04     | 1108  | 192.168.142.108   | vmbr142  | alice         | student  | template-vm-medium-02-8g-64g (9232)   |
 | student-kunai-05     | 1109  | 192.168.142.109   | vmbr142  | alice         | student  | template-vm-medium-02-8g-64g (9232)   |
 
-Single in-VM user `alice` on every VM (project convention - matches demo_lab and the blank scenarios). SSH transport user is also `alice` on every VM.
+The "In-VM user" column is the SSH transport / deploy user (`alice` on every VM, project convention). Each VM ALSO has a human sudo account - `trainer` on the trainer VM, `student` on each student VM - created by Phase 1B (see the [User model](#user-model-phase-1b) section).
 
 Source of truth : `manifest/scenario_vms.json`.
 
@@ -66,7 +86,7 @@ For the project-wide view of which VMIDs and IPs are reserved across all scenari
 
 ## kunai-project repositories
 
-The stage_01 software install step clones the 5 repositories below into `/home/<operator_user>/kunai-project/` on each VM (depth 1, force-updated on re-run).
+The stage_01 software install step clones the 5 repositories below into the human user's home (`/home/trainer/kunai-project/` on the trainer, `/home/student/kunai-project/` on each student ; depth 1, force-updated on re-run).
 
 | Repository           | Source                                                  | Purpose                                                        |
 |----------------------|---------------------------------------------------------|----------------------------------------------------------------|
@@ -106,9 +126,15 @@ range42-context delete            # same as delete-vms here (template 9232 is sh
 Once the playbook completes :
 
 ```
-ssh r42.admin-trainer-kunai   # trainer, SSH as alice, repos under /home/alice/kunai-project/
-ssh r42.student-kunai-01      # student 01, SSH as alice, repos under /home/alice/kunai-project/
-# ... and so on for student-kunai-02 .. 05
+# operator (deploy transport) connects as alice :
+ssh r42.admin-trainer-kunai   # trainer VM
+ssh r42.student-kunai-01      # student 01 ... through student-kunai-05
+
+# workshop accounts (passwords + key files -> secrets/created_users.json) :
+#   trainer VM  -> user `trainer` (repos under /home/trainer/kunai-project/)
+#   student VMs -> user `student` (repos under /home/student/kunai-project/)
+# from the trainer VM, the trainer reaches each student directly :
+#   ssh student-kunai-01      # ... through student-kunai-05 (via ~trainer/.ssh/config)
 ```
 
 All 6 VMs reach via ProxyJump through the Proxmox jumper. Each has its own explicit `Host r42.*` entry in `~/.ssh/config_range42-*` (no wildcard pattern).
@@ -133,6 +159,7 @@ All 6 VMs reach via ProxyJump through the Proxmox jumper. Each has its own expli
 | `kunai_lab.delete_vms_only.sh` | Destroys the 6 kunai_lab VMs, preserves the template. |
 | `kunai_lab.delete_all.sh` | Alias of `delete_vms_only.sh` (template 9232 is shared, never owned by kunai_lab). |
 | `kunai_lab.reset.setup.sh` | Convenience : delete the 6 VMs + redeploy in one shot. |
+| `kunai_lab.reset.ssh_keys.sh` | Clear `~/.ssh/known_hosts` entries for every manifest IP after a redeploy reuses the same IPs (fixes REMOTE HOST IDENTIFICATION CHANGED). |
 
 All scripts require `RANGE42_ANSIBLE_ROLES__INVENTORY_DIR` and `RANGE42_VAULT_PASSWORD_FILE` to be exported - set by `range42-context use <codename> kunai_lab`.
 
@@ -150,6 +177,7 @@ kunai_lab/
   kunai_lab.delete_vms_only.sh               VM teardown
   kunai_lab.delete_all.sh                    alias
   kunai_lab.reset.setup.sh                   teardown + deploy
+  kunai_lab.reset.ssh_keys.sh                clear known_hosts for all manifest IPs
   01_templates-bootstrap/                    Ubuntu noble cloud-init image + template 9232
   02_admin_infrastructure/                   scaffold for future Wazuh / MISP (gated off)
   03_trainer_infrastructure/                 trainer VM (admin-trainer-kunai) - stage_00 + stage_01

--- a/scenarios/kunai_lab/_finalize-created_users_record.yml
+++ b/scenarios/kunai_lab/_finalize-created_users_record.yml
@@ -1,0 +1,44 @@
+---
+##
+## kunai_lab - record the created human users (+ derived passwords + key hint) to the workspace.
+## Runs on the controller (deployer-cli) after the user provisioning ; reads the per-host creds
+## facts set by the baselines' compute-creds plays. Passwords are DERIVED (not known otherwise),
+## so this JSON is the operator's reference to hand credentials + keys to the students + trainer.
+##
+## Output : ~/range42.config/<codename>-<scenario>/secrets/created_users.json
+## NB : holds cleartext derived passwords -> 0600 ; fold into the vault-encryption backlog (v2).
+##
+
+- name: kunai_lab - record created human users to secrets/created_users.json
+  hosts: localhost
+  gather_facts: false
+  run_once: true
+  tasks:
+    - name: assert the creds facts were computed for every student host
+      ansible.builtin.assert:
+        that:
+          - hostvars[item]._kunai_student_password is defined
+        fail_msg: "no _kunai_student_password fact for {{ item }} - the compute-creds play did not run for this host (deploy order issue)"
+      loop: "{{ groups['r42_kunai_lab_students_group'] | default([]) }}"
+
+    - name: collect student creds (per VM, unique key + password)
+      ansible.builtin.set_fact:
+        _kunai_students_rec: "{{ _kunai_students_rec | default([]) + [ {'vm': item | regex_replace('^r42\\.', ''), 'user': 'student', 'password': hostvars[item]._kunai_student_password | default(''), 'ssh_key': 'ssh_keys/student_keys/additional.students/*-student-key_bob_' ~ (hostvars[item].student_key_index | default('?'))} ] }}"
+      loop: "{{ groups['r42_kunai_lab_students_group'] | default([]) }}"
+      no_log: true
+
+    - name: collect the trainer creds (single ; same password on every VM)
+      ansible.builtin.set_fact:
+        _kunai_trainer_rec:
+          vm: "{{ (groups['r42_kunai_lab_trainer_group'] | default(['n/a']))[0] | regex_replace('^r42\\.', '') }}"
+          user: "trainer"
+          password: "{{ hostvars[(groups['r42_kunai_lab_trainer_group'] | default(['']))[0]]._kunai_trainer_password | default('') }}"
+          ssh_key_inbound: "ssh_keys/student_keys/*-student-key_bob"
+      no_log: true
+
+    - name: write created_users.json
+      ansible.builtin.copy:
+        dest: "{{ lookup('env', 'RANGE42_ACTIVE_CONFIG_DIR') }}/secrets/created_users.json"
+        mode: "0600"
+        content: "{{ {'students': (_kunai_students_rec | default([])), 'trainer': (_kunai_trainer_rec | default({})), 'notes': ['SSH keys live in this workspace under ssh_keys/student_keys/ (paths above are relative to the workspace root ; expand the glob for the exact filename).', 'students log in with their bob_N private key (handed off out-of-band by the trainer) or the password below.', 'trainer INBOUND key (to log into the trainer VM) = the bob base key (ssh_key_inbound above).', 'trainer -> students uses a passphrase-less trainer-student-access key that lives ONLY on the trainer VM (generated there, never handed off).', 'all human accounts (student, trainer) have NOPASSWD sudo - intentional for the lab.']} | to_nice_json }}"
+      no_log: true

--- a/scenarios/kunai_lab/_finalize-trainer_student_access.yml
+++ b/scenarios/kunai_lab/_finalize-trainer_student_access.yml
@@ -1,0 +1,30 @@
+---
+##
+## kunai_lab - push the trainer-student-access pubkey to the students' `trainer` authorized_keys.
+## Cross-tier finalize : runs AFTER all stage_01 (the key is generated on the trainer VM by
+## _finalize-trainer_ssh_config.yml, and the students' `trainer` user exists). ADDITIVE
+## (AUTHORIZED_KEY_EXCLUSIVE: false) - never removes existing keys (alice is a separate account,
+## untouched ; the trainer private key stays ONLY on the trainer VM).
+##
+
+- name: kunai_lab - read the trainer-student-access public key (from the trainer VM)
+  hosts: r42_kunai_lab_trainer_group
+  gather_facts: false
+  become: true
+  tasks:
+    - name: slurp trainer-student-access.pub
+      ansible.builtin.slurp:
+        src: /home/trainer/.ssh/trainer-student-access.pub
+      register: _tsa_pub_raw
+
+    - name: expose the pubkey as a fact
+      ansible.builtin.set_fact:
+        _kunai_trainer_access_pubkey: "{{ _tsa_pub_raw.content | b64decode | trim }}"
+
+- import_playbook: "{{ lookup('env', 'RANGE42_GITDIR__ROOT_DIR') }}/range42-playbooks/bundles/core/systems.configure.authorized_keys/main.yml"
+  when: groups['r42_kunai_lab_trainer_group'] | default([]) | length > 0
+  vars:
+    TARGET_GROUP: "r42_kunai_lab_students_group"
+    TARGET_USER: "trainer"
+    AUTHORIZED_KEY: "{{ hostvars[groups['r42_kunai_lab_trainer_group'][0]]._kunai_trainer_access_pubkey }}"
+    AUTHORIZED_KEY_EXCLUSIVE: false

--- a/scenarios/kunai_lab/main.yml
+++ b/scenarios/kunai_lab/main.yml
@@ -57,6 +57,18 @@
 
 - import_playbook: ./04_student_infrastructure/_main_stage_01.yml
 
+#
+# Phase 1B : push the trainer-student-access pubkey to the students' `trainer` authorized_keys.
+# Runs after ALL stage_01 (the key is generated on the trainer VM, the students' trainer user exists).
+#
+- import_playbook: ./_finalize-trainer_student_access.yml
+
+#
+# Phase 1B : record the created human users (+ derived passwords) to the workspace.
+# Runs after ALL stage_01 (the compute-creds facts are set on the trainer + student VMs).
+#
+- import_playbook: ./_finalize-created_users_record.yml
+
 #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
 #### #### #### #### BUILD r42_kunai_lab_wazuh_clients_active  #### #### ####
 #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####

--- a/scenarios/kunai_lab/main_vms_only.yml
+++ b/scenarios/kunai_lab/main_vms_only.yml
@@ -32,6 +32,13 @@
 
 - import_playbook: ./04_student_infrastructure/_main_stage_01.yml
 
+#
+# Phase 1B cross-tier finalizes (MUST mirror main.yml) : trainer->student access + created_users record.
+#
+- import_playbook: ./_finalize-trainer_student_access.yml
+
+- import_playbook: ./_finalize-created_users_record.yml
+
 #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
 #### #### #### #### BUILD r42_kunai_lab_wazuh_clients_active  #### #### ####
 #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####

--- a/scenarios/kunai_lab/templates/ansible-inventory.j2
+++ b/scenarios/kunai_lab/templates/ansible-inventory.j2
@@ -17,11 +17,18 @@ all:
 
         r42_kunai_lab_students_group:
           hosts:
+            # student_key_index -> selects the per-VM unique student SSH key
+            # (ssh_key_student_user_extra_<N>_pub_key in the vault) for the human `student` user.
             r42.student-kunai-01:
+              student_key_index: 1
             r42.student-kunai-02:
+              student_key_index: 2
             r42.student-kunai-03:
+              student_key_index: 3
             r42.student-kunai-04:
+              student_key_index: 4
             r42.student-kunai-05:
+              student_key_index: 5
 
         ####
 

--- a/scenarios/kunai_lab/templates/ansible-vars.yml
+++ b/scenarios/kunai_lab/templates/ansible-vars.yml
@@ -4,8 +4,8 @@
 #
 # These variables are specific to this scenario. kunai_lab is a 6-VM training
 # scenario delivering Ubuntu LTS hosts pre-provisioned with the Docker baseline
-# plus the kunai-project ecosystem repositories pre-cloned in the operator home
-# (alice on the trainer VM, bob on the 5 student VMs).
+# plus the kunai-project ecosystem repositories. alice = cloud-init/deploy user on all
+# 6 VMs ; the human sudo users (trainer + student) are created per-VM by the scenario.
 #
 # For shared variables -> group_vars/all/vars.yml
 # For secrets -> vault.yml (see vault.yml.example)
@@ -24,14 +24,21 @@ INFRASTRUCTURE_SCENARIO: "kunai_lab"
 context_auto_generate_ssh_keys: "YES"
 context_auto_generate_vm_passwords: "YES"
 
-# number of additional student ssh keys (bob_1 .. bob_N)
-# no student extras for kunai_lab (single in-VM user alice on every VM, project convention)
-student_additionnal_keys_count: 0
+# number of additional student ssh keys (bob_1 .. bob_N) - one per student VM (5).
+# SINGLE-n spelling : MUST match the wizard var (credentials.generate) so it actually
+# governs the generated count (the double-n form is dead config). Used as the per-VM
+# UNIQUE SSH key for the human `student` user (Phase 1B provisioning).
+student_additional_keys_count: 5
 
 
 #### CLOUD-INIT USERNAMES ####
 
 # admin vm user (not secret - password and ssh key are in vault)
 # cloud-init user is alice on all 6 VMs (medium template default, project
-# convention - matches demo_lab and the blank scenarios)
+# convention - matches demo_lab and the blank scenarios). alice = DEPLOY user.
 default_admin_vm_ci_user: "alice"
+
+# trainee tier : drives the wizard to generate the bob base key + trainee password + bob_1..N.
+# Consumed by the scenario user-provisioning bundles to create the HUMAN sudo users `student`
+# (per-VM unique key) + `trainer` (Phase 1B). alice stays the deploy user.
+default_trainee_vm_ci_user: "bob"

--- a/scenarios/kunai_lab/templates/vault-example.yml
+++ b/scenarios/kunai_lab/templates/vault-example.yml
@@ -38,6 +38,13 @@ default_admin_vm_ci_password: "REPLACE_ME"
 # admin vm (alice) ssh public key - populated by credentials.generate
 default_admin_vm_ci_ssh_key: "ssh-ed25519 AAAA... alice CODENAME-SCENARIO"
 
+# trainee (bob) password + ssh key - populated by the wizard.
+# The human `student` (per-VM) + `trainer` users derive their password from their per-VM pubkey
+# + this secret ; the bob_1..N extra pubkeys (ssh_key_student_user_extra_N_pub_key in the generated
+# vault) are the per-VM unique SSH keys. alice remains the deploy user.
+default_trainee_vm_ci_password: "REPLACE_ME"
+default_trainee_vm_ci_ssh_key: "ssh-ed25519 AAAA... bob CODENAME-SCENARIO"
+
 
 #### WAZUH ####
 


### PR DESCRIPTION

The kunai_lab workshop scenario plus the thin bundles that wire the catalog roles onto a target group. Depends on the range42-catalog kunai_lab PR (roles).

## Thin bundles (`bundles/core/`)

- `software.install.kunai_official_workshop`, `software.install.warmup.dot_files`
- composable user-provisioning: `systems.configure.{add_user,authorized_keys,ssh_keypair,sudo}` and `systems.configure.os_auto_updates`

## kunai_lab scenario (#115)

- User model: `alice` stays the deploy / transport user; a `trainer` (sudo) on the trainer VM; a per-VM `student` (sudo, unique derived password) on each student VM; `trainer` also present on each student VM for SSH-in. Built entirely at scenario level via the bundles, no wizard / core change.
- Trainer to student SSH via a passphrase-less key generated on the trainer VM and pushed to the students.
- Dotfiles (zsh + oh-my-zsh + vimrc) for every human user and root.
- Kunai toolchain always installed (it is the core of the lab).
- OS background auto-updates disabled first in both baselines (frees the dpkg lock before any apt task).
- A created-users record is written to the workspace secrets dir.
