### PR TITLE
fix(dev_deployer_ui_lab): align backend bundle CORS + docs with app config contract

### DIFF
--- a/bundles/admin/software.install.deployer_api_backend/README.md
+++ b/bundles/admin/software.install.deployer_api_backend/README.md
@@ -38,6 +38,7 @@ Kong is parallel/not in the UI->backend path for this POC (kong.yml is empty).
 | `REMOTE_PROJECT_DIR` | `/var/www/range42_backend_api` |
 | `API_PORT` | `8000` |
 | `WORKSPACE_DIR_HOST` | `/home/range42/range42.config` |
+| `PLAYBOOKS_DEST_DIR` | `/home/range42/range42-playbooks` |
 | `DEPLOYER_UI_CORS_REGEX` | `^https?://r42\.admin-deployer-ui(:\d+)?$` |
 
 ## Call-site example
@@ -52,17 +53,18 @@ Kong is parallel/not in the UI->backend path for this POC (kong.yml is empty).
 ## What runs
 
 The bundle mirrors the upstream README's Quick Start - Option 1 (Docker) :
-`docker compose up` against an image built from local source. No source
-bind-mount at runtime ; code, playbooks, and inventory are baked into the
-image at build time. Schema bootstrap is handled in-process by the app on
-startup, so no explicit migration step is needed.
+`docker compose up` against an image built from local source. The backend-api
+source is baked into the image at build time ; the range42-playbooks repo is
+bind-mounted read-only at runtime (the backend's ansible-runner reads its
+scenarios + bundles tree). Schema is migrated at deploy time via an explicit
+`alembic upgrade head` step (see the Database section below).
 
 1. **Docker install** : invokes `software.install.warmup.basic_packages` role with `INSTALL_PACKAGES_DOCKER=YES` + `INSTALL_PACKAGES_DOCKER_COMPOSE=YES` (Docker Engine + compose plugin via the project's standard install path)
 2. **Firewall** : applies `software.configure.firewalls` role with rules for ports 22 + API_PORT
 3. **Workspace dir** : creates `/home/range42/range42.config/` on the host owned by UID/GID 1000 (mode 0700) - holds the SQLite DB + events.jsonl + ansible-runner artefacts + per-deployment `<C>-<S>/secrets/vault_pass.txt` ; persists across container restarts
 4. **Sync source (build context)** : rsync's the backend-api repo from the controller to `REMOTE_PROJECT_DIR` (excludes `.git`, `.venv`, `collections`, `__pycache__`, `.pytest_cache`, `.env*`). This is the Docker build context only - the source is BAKED into the image at build time, NOT bind-mounted at runtime
 5. **Render .env** : writes the env file consumed by docker compose (PORT, UID/GID, IMAGE_NAME, SSH_KEY_PATH, VAULT_PASSWORD_FILE empty by default, CORS_ORIGIN_REGEX, RANGE42_WORKSPACE_ROOT, WEB_CONCURRENCY=1, UVICORN_WORKERS=1, DEBUG=false)
-6. **Render docker-compose.override.yml** : single runtime bind-mount of the workspace dir. The upstream compose's SSH key mount is preserved.
+6. **Render docker-compose.override.yml** : two runtime bind-mounts - the workspace dir (RW) and the range42-playbooks repo (RO). The upstream compose's SSH key mount is preserved.
 7. **Compose up** : `docker compose up -d --build` builds the multi-stage image locally on the VM the first time (Python 3.13 builder + slim runtime), then starts the container
 8. **Verify** : waits for the API port + probes `/docs/openapi.json` (same endpoint the container's HEALTHCHECK uses) - expects HTTP 200
 
@@ -96,20 +98,11 @@ btrfs / zfs / tmpfs). The backend refuses NFS / CIFS / FUSE at deployment-
 create with HTTP 409 / `WORKSPACE_NON_LOCAL_FS`. The bundle uses a host path
 that is local FS by construction (system disk).
 
-Schema bootstrap is handled in-process by the app on startup (per the
-upstream README's Quick Start - `docker compose up` is sufficient). No
-explicit `alembic upgrade head` step in the bundle. If a future schema
-bump requires manual migration, run it once on the host with the source
-tree available :
-
-```bash
-cd /var/www/range42_backend_api
-docker run --rm -v "$(pwd)/alembic.ini:/app/alembic.ini:ro" \
-                -v "$(pwd)/alembic:/app/alembic:ro" \
-                --env-file .env \
-                range42-backend-api:local \
-                alembic upgrade head
-```
+Schema is migrated at deploy time. The bundle runs `alembic upgrade head`
+via `docker compose run --rm` right after `docker compose up`, bind-mounting
+`alembic.ini` + `alembic/` from the rsynced source (the upstream image does
+not bake them in). The app does not create tables on startup, so this step is
+required for a fresh DB ; re-running the bundle re-applies it idempotently.
 
 ## Vault password file
 

--- a/bundles/admin/software.install.deployer_api_backend/main.yml
+++ b/bundles/admin/software.install.deployer_api_backend/main.yml
@@ -26,7 +26,7 @@
 #        r42.deployer-key_<user> via relative symlinks)
 #      - Rsync the range42-playbooks repo from controller to
 #        /home/range42/range42-playbooks/ (bind-mounted RO into container ;
-#        used by backend to launch ansible-runner against scenarios/_universal)
+#        read by the backend's in-container ansible-runner)
 #      - Rsync the backend-api source (Docker build context only, BAKED into
 #        the image at build time per upstream README, not bind-mounted)
 #      - Render .env (PORT, UID/GID, CORS, RANGE42_WORKSPACE_ROOT,
@@ -293,8 +293,8 @@
           RANGE42_WORKSPACE_ROOT=/home/range42/range42.config
 
           # Playbooks repo INSIDE the container (bind-mounted RO via override compose).
-          # Must contain scenarios/_universal/main.yml (per Philippe's design ; the
-          # backend launches ansible-runner against this path).
+          # Provides the range42-playbooks scenarios + bundles tree that the
+          # backend's in-container ansible-runner reads at deploy time.
           API_BACKEND_WWWAPP_PLAYBOOKS_DIR=/home/range42/range42-playbooks
 
           # SQLite DB - file lives in the workspace bind-mount, so it survives
@@ -320,9 +320,9 @@
           # Managed by range42 - additional bind-mounts on top of the upstream compose.
           # 1. Workspace dir (RW) : SQLite + events.jsonl + per-deployment secrets/
           #    (vault_pass.txt + default_vault.yml) + ssh_keys/ + inventory/.
-          # 2. Playbooks repo (RO) : ansible-runner reads from here to launch
-          #    scenarios/_universal and its bundles. Read-only by design ; updates
-          #    require a fresh bundle run (which re-rsyncs from controller).
+          # 2. Playbooks repo (RO) : ansible-runner reads the scenarios + bundles
+          #    tree from here. Read-only by design ; updates require a fresh bundle
+          #    run (which re-rsyncs from controller).
           services:
             api:
               volumes:

--- a/scenarios/dev_deployer_ui_lab/02_dev_deployer_ui_lab_infrastructure/stage_01-vm_configure/dev-backend.yml
+++ b/scenarios/dev_deployer_ui_lab/02_dev_deployer_ui_lab_infrastructure/stage_01-vm_configure/dev-backend.yml
@@ -22,3 +22,7 @@
   vars:
     global_vm_ssh_name: "r42.dev-backend"
     global_vm_ci_ip:    "192.168.142.191"
+    # CORS: this lab's UI is r42.dev-deployer-ui (192.168.142.190), not the
+    # bundle default r42.admin-deployer-ui. Match the origin(s) the operator
+    # browses the UI from (ssh name or IP), else the browser blocks UI->backend.
+    DEPLOYER_UI_CORS_REGEX: '^https?://(r42\.dev-deployer-ui|192\.168\.142\.190)(:\d+)?$'

--- a/scenarios/dev_deployer_ui_lab/manifest/feature_flags.yml
+++ b/scenarios/dev_deployer_ui_lab/manifest/feature_flags.yml
@@ -19,7 +19,7 @@
 features:
   - id: DEPLOYER_UI
     label: "deployer-ui (frontend SPA)"
-    description: "Deploys the range42-deployer-ui frontend (Node 24 multi-stage build, nginx serve, port 80) on the dev-deployer-ui VM via the canonical Docker bundle. Skipping leaves the VM as a bare Docker host."
+    description: "Deploys the range42-deployer-ui frontend (Node 24 multi-stage build, nginx on container port 80 published on host UI_PORT default 3000) on the dev-deployer-ui VM via the canonical Docker bundle. Skipping leaves the VM as a bare Docker host."
     default: true
 
   - id: DEPLOYER_API_BACKEND


### PR DESCRIPTION
Part of range42/range42-playbooks#131 (align the deployer-ui/backend bundle config contract).

- **CORS**: `dev-backend` call-site now sets `DEPLOYER_UI_CORS_REGEX` to match this lab's UI (`r42.dev-deployer-ui` / `192.168.142.190`). The bundle default targets `r42.admin-deployer-ui` and would block the browser. **Value is a placeholder** — needs confirming against the origin operators actually browse from.
- **backend bundle README**: aligned to `main.yml` (alembic runs at deploy, two bind-mounts, `PLAYBOOKS_DEST_DIR`).
- dropped the stale `scenarios/_universal` references from the bundle (backend will not use it).
- `feature_flags`: clarified the deployer-ui port (nginx container:80 → host UI_PORT default 3000).

Refs #131.