### PR TITLE
fix(bundles): add configure/terminfo bundle — install alacritty terminfo on remote hosts

### DIFF
--- a/bundles/core/linux/ubuntu/configure/terminfo/main.yml
+++ b/bundles/core/linux/ubuntu/configure/terminfo/main.yml
@@ -1,0 +1,46 @@
+##
+## configure/terminfo — install alacritty terminfo on remote hosts
+##
+## Ubuntu 24.04 minimal images do not ship the alacritty terminfo entry.
+## SSH forwards the local TERM value, so connecting from an Alacritty session
+## triggers "'alacritty': unknown terminal type." on the remote.
+##
+## This play copies the alacritty terminfo binary from the Ansible controller
+## (where Alacritty is installed) to /etc/terminfo/a/alacritty on each target,
+## and configures sshd to accept the TERM environment variable from the client.
+##
+## Caller: scenarios import this via `import_playbook` in their stage_01,
+## overriding `hosts` to the relevant inventory group (e.g. r42_admin_services_lab_group).
+## Relates to: range42/range42#227
+##
+
+- name: configure sshd and alacritty terminfo
+  hosts: all
+  become: true
+  tasks:
+    - name: allow SSH client to forward TERM environment variable
+      ansible.builtin.lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: '^AcceptEnv TERM'
+        insertafter: '^AcceptEnv LANG LC_\*'
+        line: 'AcceptEnv TERM'
+      notify: reload sshd
+
+    - name: ensure /etc/terminfo/a directory exists
+      ansible.builtin.file:
+        path: /etc/terminfo/a
+        state: directory
+        mode: '0755'
+
+    - name: install alacritty terminfo so TERM=alacritty works over SSH
+      ansible.builtin.copy:
+        src: /usr/share/terminfo/a/alacritty
+        dest: /etc/terminfo/a/alacritty
+        mode: '0644'
+      ignore_errors: true
+
+  handlers:
+    - name: reload sshd
+      ansible.builtin.service:
+        name: ssh
+        state: reloaded


### PR DESCRIPTION
## Summary

- Adds `bundles/core/linux/ubuntu/configure/terminfo/main.yml`
- Configures sshd to accept the `TERM` env var from the SSH client (`AcceptEnv TERM`)
- Copies the alacritty terminfo binary from the Ansible controller to `/etc/terminfo/a/alacritty` on each target host

Companion to range42/range42#228 which fixes the deployer-side TERM export. This bundle fixes the server side: Ubuntu 24.04 minimal images don't ship the `alacritty` terminfo entry, so connecting from an Alacritty session triggers `'alacritty': unknown terminal type.` on the remote.

Relates to range42/range42#227.

## Usage

```yaml
- import_playbook: bundles/core/linux/ubuntu/configure/terminfo/main.yml
```

Override `hosts` in the importing scenario's stage_01 to target the relevant inventory group.

## Test plan

- [ ] Run bundle against a fresh Ubuntu 24.04 VM from an Alacritty session
- [ ] Confirm `TERM=alacritty` is forwarded and accepted by sshd
- [ ] Confirm no `unknown terminal type` error in the remote shell