### PR TITLE
fix(dev_deployer_ui_lab): fail fast on a stale workspace, stamp deployed source, seed the SPA backend

### DIFF
--- a/bundles/admin/software.install.deployer_api_backend/README.md
+++ b/bundles/admin/software.install.deployer_api_backend/README.md
@@ -82,13 +82,19 @@ playbooks_source_path=/home/alice/range42-playbooks/
 backend_api_ref=dev
 backend_api_sha=257e62a
 backend_api_dirty=0
+backend_api_upstream=origin/dev
+backend_api_unpushed=0
 playbooks_ref=fix/dev-deployer-ui-lab-hardening
-playbooks_sha=bafe53a
+playbooks_sha=498b875
 playbooks_dirty=9
+playbooks_upstream=origin/fix/dev-deployer-ui-lab-hardening
+playbooks_unpushed=0
 deployed_at=2026-08-10T09:29:40Z
 ```
 
-`*_dirty=0` is the only evidence that what runs on the VM matches a pushed commit. The file lives outside `REMOTE_PROJECT_DIR` on purpose — inside, its timestamp would bust the Docker build cache on every no-op re-run.
+Reading it: `*_dirty=0` on its own proves nothing about reproducibility — a commit that was never pushed is perfectly clean, and its sha exists on no remote. A tree is recoverable from a remote only when **`*_dirty=0` and `*_unpushed=0` and `*_upstream` is not `none`**. `*_dirty` is the uncommitted-file count, nothing more.
+
+The file lives outside `REMOTE_PROJECT_DIR` on purpose — inside, its timestamp would bust the Docker build cache on every no-op re-run.
 
 ## CORS configuration
 

--- a/bundles/admin/software.install.deployer_api_backend/README.md
+++ b/bundles/admin/software.install.deployer_api_backend/README.md
@@ -63,10 +63,32 @@ scenarios + bundles tree). Schema is migrated at deploy time via an explicit
 2. **Firewall** : applies `software.configure.firewalls` role with rules for ports 22 + API_PORT
 3. **Workspace dir** : creates `/home/range42/range42.config/` on the host owned by UID/GID 1000 (mode 0700) - holds the SQLite DB + events.jsonl + ansible-runner artefacts + per-deployment `<C>-<S>/secrets/vault_pass.txt` ; persists across container restarts
 4. **Sync source (build context)** : rsync's the backend-api repo from the controller to `REMOTE_PROJECT_DIR` (excludes `.git`, `.venv`, `collections`, `__pycache__`, `.pytest_cache`, `.env*`). This is the Docker build context only - the source is BAKED into the image at build time, NOT bind-mounted at runtime
-5. **Render .env** : writes the env file consumed by docker compose (PORT, UID/GID, IMAGE_NAME, SSH_KEY_PATH, VAULT_PASSWORD_FILE empty by default, CORS_ORIGIN_REGEX, RANGE42_WORKSPACE_ROOT, WEB_CONCURRENCY=1, UVICORN_WORKERS=1, DEBUG=false)
-6. **Render docker-compose.override.yml** : two runtime bind-mounts - the workspace dir (RW) and the range42-playbooks repo (RO). The upstream compose's SSH key mount is preserved.
-7. **Compose up** : `docker compose up -d --build` builds the multi-stage image locally on the VM the first time (Python 3.13 builder + slim runtime), then starts the container
-8. **Verify** : waits for the API port + probes `/docs/openapi.json` (same endpoint the container's HEALTHCHECK uses) - expects HTTP 200
+5. **Record provenance** : captures the controller-side `ref` / short `sha` / dirty-file count of BOTH synced trees (backend-api + playbooks) into `/var/lib/range42/deployer_api_backend.version` and echoes them in the play output
+6. **Render .env** : writes the env file consumed by docker compose (PORT, UID/GID, IMAGE_NAME, SSH_KEY_PATH, VAULT_PASSWORD_FILE empty by default, CORS_ORIGIN_REGEX, RANGE42_WORKSPACE_ROOT, WEB_CONCURRENCY=1, UVICORN_WORKERS=1, DEBUG=false)
+7. **Render docker-compose.override.yml** : two runtime bind-mounts - the workspace dir (RW) and the range42-playbooks repo (RO). The upstream compose's SSH key mount is preserved.
+8. **Compose up** : `docker compose up -d --build` builds the multi-stage image locally on the VM the first time (Python 3.13 builder + slim runtime), then starts the container
+9. **Verify** : waits for the API port + probes `/docs/openapi.json` (same endpoint the container's HEALTHCHECK uses) - expects HTTP 200
+
+## Source provenance
+
+This bundle deploys the **controller's working trees**, not git clones — for both `range42-backend-api` (the image build context) and `range42-playbooks` (the tree the in-container ansible-runner reads at deploy time). Branch, local commits and uncommitted edits all ship as-is. That is what makes a dev lab fast, but it means what runs here can exist on no git remote.
+
+Step 5 therefore records what was actually shipped :
+
+```
+# /var/lib/range42/deployer_api_backend.version
+backend_api_source_path=/home/alice/range42-backend-api/
+playbooks_source_path=/home/alice/range42-playbooks/
+backend_api_ref=dev
+backend_api_sha=257e62a
+backend_api_dirty=0
+playbooks_ref=fix/dev-deployer-ui-lab-hardening
+playbooks_sha=bafe53a
+playbooks_dirty=9
+deployed_at=2026-08-10T09:29:40Z
+```
+
+`*_dirty=0` is the only evidence that what runs on the VM matches a pushed commit. The file lives outside `REMOTE_PROJECT_DIR` on purpose — inside, its timestamp would bust the Docker build cache on every no-op re-run.
 
 ## CORS configuration
 

--- a/bundles/admin/software.install.deployer_api_backend/main.yml
+++ b/bundles/admin/software.install.deployer_api_backend/main.yml
@@ -83,10 +83,14 @@
 #   Both rsyncs copy the controller's checkouts as-is - branch, local commits
 #   and uncommitted edits included. That is deliberate for a dev lab (edit,
 #   redeploy, no push round-trip), but it means what runs here can exist on no
-#   git remote. So the run records ref / short sha / dirty file count for
-#   range42-backend-api AND range42-playbooks in
-#   /var/lib/range42/deployer_api_backend.version and echoes them in the play
-#   output. `*_dirty=0` is the only evidence the deploy matches a pushed commit.
+#   git remote. So the run records ref / short sha / uncommitted file count /
+#   upstream branch / unpushed commit count for range42-backend-api AND
+#   range42-playbooks in /var/lib/range42/deployer_api_backend.version and
+#   echoes them in the play output.
+#   Reading it : `*_dirty=0` alone proves nothing about reproducibility - a
+#   commit that was never pushed is perfectly clean. A tree's sha exists on a
+#   remote only when `*_dirty=0` AND `*_unpushed=0` AND `*_upstream` is not
+#   `none`.
 #
 # Precondition : `range42-context use <C> <S>` MUST be active before running.
 # It exports the env vars above AND sets ANSIBLE_CONFIG so the encrypted
@@ -276,9 +280,11 @@
       ansible.builtin.shell:
         cmd: |
           cd {{ item.path | quote }}
-          printf '%s_ref=%s\n'   {{ item.key | quote }} "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
-          printf '%s_sha=%s\n'   {{ item.key | quote }} "$(git rev-parse --short HEAD     2>/dev/null || echo unknown)"
-          printf '%s_dirty=%s\n' {{ item.key | quote }} "$(git status --porcelain         2>/dev/null | wc -l)"
+          printf '%s_ref=%s\n'      {{ item.key | quote }} "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+          printf '%s_sha=%s\n'      {{ item.key | quote }} "$(git rev-parse --short HEAD     2>/dev/null || echo unknown)"
+          printf '%s_dirty=%s\n'    {{ item.key | quote }} "$(git status --porcelain         2>/dev/null | wc -l)"
+          printf '%s_upstream=%s\n' {{ item.key | quote }} "$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || echo none)"
+          printf '%s_unpushed=%s\n' {{ item.key | quote }} "$(git rev-list --count '@{upstream}..HEAD' 2>/dev/null || echo unknown)"
         executable: /bin/bash
       delegate_to: localhost
       become: false

--- a/bundles/admin/software.install.deployer_api_backend/main.yml
+++ b/bundles/admin/software.install.deployer_api_backend/main.yml
@@ -279,7 +279,9 @@
     - name: Capture controller-side git provenance of the synced trees
       ansible.builtin.shell:
         cmd: |
-          cd {{ item.path | quote }}
+          # Bail rather than run git in the playbook cwd (also a repo) and
+          # stamp the wrong tree. failed_when:false keeps the deploy going.
+          cd {{ item.path | quote }} || exit 1
           printf '%s_ref=%s\n'      {{ item.key | quote }} "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
           printf '%s_sha=%s\n'      {{ item.key | quote }} "$(git rev-parse --short HEAD     2>/dev/null || echo unknown)"
           printf '%s_dirty=%s\n'    {{ item.key | quote }} "$(git status --porcelain         2>/dev/null | wc -l)"

--- a/bundles/admin/software.install.deployer_api_backend/main.yml
+++ b/bundles/admin/software.install.deployer_api_backend/main.yml
@@ -43,7 +43,8 @@
 #   5. Wait for /docs/openapi.json to return 200 (container HEALTHCHECK uses
 #      the same endpoint).
 #   6. Post-deploy seed : register the Proxmox host with the backend via
-#      POST /v1/proxmox/hosts (idempotent via 409 ; reads creds from
+#      POST /v1/proxmox/hosts (idempotent : the backend keys on `name` and
+#      updates in place, keeping the host id stable ; reads creds from
 #      <workspace>/secrets/default_vault.yml). Required before any deploy
 #      via the backend can succeed (the backend looks up target_host_id in
 #      its proxmox_hosts table).
@@ -481,7 +482,7 @@
   vars:
     API_PORT_RESOLVED: "{{ API_PORT | default('8000') }}"
   tasks:
-    - name: Register Proxmox host with backend (idempotent via 409)
+    - name: Register Proxmox host with backend (idempotent upsert on name)
       ansible.builtin.uri:
         url: "http://127.0.0.1:{{ API_PORT_RESOLVED }}/v1/proxmox/hosts"
         method: POST
@@ -491,9 +492,12 @@
           api_url: "https://{{ proxmox_api_host }}"
           node_name: "{{ proxmox_node }}"
           token_ref: "{{ proxmox_api_user }}!{{ proxmox_api_token_id }}={{ proxmox_api_token_secret }}"
-        status_code: [200, 201, 409]
+        # 201 = first registration, 200 = re-seed of an existing host (the
+        # backend refreshes api_url / node / token and keeps the same id, so
+        # deployments already pointing at it stay valid).
+        status_code: [200, 201]
       register: register_proxmox_result
 
     - name: Show Proxmox host registration result
       ansible.builtin.debug:
-        msg: "Proxmox host registration on backend : HTTP {{ register_proxmox_result.status }} (200/201 = created, 409 = already registered)"
+        msg: "Proxmox host registration on backend : HTTP {{ register_proxmox_result.status }} (201 = registered, 200 = already registered, refreshed in place)"

--- a/bundles/admin/software.install.deployer_api_backend/main.yml
+++ b/bundles/admin/software.install.deployer_api_backend/main.yml
@@ -29,6 +29,8 @@
 #        read by the backend's in-container ansible-runner)
 #      - Rsync the backend-api source (Docker build context only, BAKED into
 #        the image at build time per upstream README, not bind-mounted)
+#      - Record the controller-side git provenance of both synced trees in
+#        /var/lib/range42/deployer_api_backend.version (see below)
 #      - Render .env (PORT, UID/GID, CORS, RANGE42_WORKSPACE_ROOT,
 #        API_BACKEND_WWWAPP_PLAYBOOKS_DIR, RANGE42_DB_URL,
 #        WEB_CONCURRENCY=1 invariant)
@@ -75,6 +77,15 @@
 #   - RANGE42_INFRASTRUCTURE_CODENAME, RANGE42_INFRASTRUCTURE_LAB
 #   - RANGE42_GITDIR__ROOT_DIR
 #   - RANGE42_ACTIVE_WORKSPACE      : <C>-<S> workspace dir name
+#
+# Source provenance (this bundle deploys the controller's WORKING TREES) :
+#   Both rsyncs copy the controller's checkouts as-is - branch, local commits
+#   and uncommitted edits included. That is deliberate for a dev lab (edit,
+#   redeploy, no push round-trip), but it means what runs here can exist on no
+#   git remote. So the run records ref / short sha / dirty file count for
+#   range42-backend-api AND range42-playbooks in
+#   /var/lib/range42/deployer_api_backend.version and echoes them in the play
+#   output. `*_dirty=0` is the only evidence the deploy matches a pushed commit.
 #
 # Precondition : `range42-context use <C> <S>` MUST be active before running.
 # It exports the env vars above AND sets ANSIBLE_CONFIG so the encrypted
@@ -259,6 +270,59 @@
           - "--exclude=.pytest_cache"
           - "--exclude=.env"
           - "--exclude=.env.local"
+
+    - name: Capture controller-side git provenance of the synced trees
+      ansible.builtin.shell:
+        cmd: |
+          cd {{ item.path | quote }}
+          printf '%s_ref=%s\n'   {{ item.key | quote }} "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+          printf '%s_sha=%s\n'   {{ item.key | quote }} "$(git rev-parse --short HEAD     2>/dev/null || echo unknown)"
+          printf '%s_dirty=%s\n' {{ item.key | quote }} "$(git status --porcelain         2>/dev/null | wc -l)"
+        executable: /bin/bash
+      delegate_to: localhost
+      become: false
+      changed_when: false
+      failed_when: false
+      loop:
+        - { key: "backend_api", path: "{{ LOCAL_CODE_PATH_RESOLVED }}" }
+        - { key: "playbooks", path: "{{ PLAYBOOKS_SRC_RESOLVED }}" }
+      loop_control:
+        label: "{{ item.key }}"
+      register: api_src_provenance
+
+    - name: Create /var/lib/range42 (provenance records, outside the build context)
+      ansible.builtin.file:
+        path: /var/lib/range42
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Record what was actually deployed (ref + sha + dirty state)
+      ansible.builtin.copy:
+        dest: /var/lib/range42/deployer_api_backend.version
+        content: |
+          # Managed by range42 / bundles/admin/software.install.deployer_api_backend
+          # Provenance of the two source trees rsynced from the controller : the
+          # backend image build context, and the playbooks tree the in-container
+          # ansible-runner reads at deploy time. dirty > 0 means this deploy
+          # carries uncommitted controller-side edits and matches no commit on
+          # any remote.
+          backend_api_source_path={{ LOCAL_CODE_PATH_RESOLVED }}
+          playbooks_source_path={{ PLAYBOOKS_SRC_RESOLVED }}
+          {% for line in api_src_provenance.results | map(attribute='stdout_lines') | flatten %}
+          {{ line }}
+          {% endfor %}
+          deployed_at={{ ansible_facts.date_time.iso8601 }}
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Show the deployed source provenance
+      ansible.builtin.debug:
+        msg: >-
+          deployed sources :
+          {{ api_src_provenance.results | map(attribute='stdout_lines') | flatten | join(' ') }}
 
     - name: Render .env (PORT, UID/GID, CORS, workspace path, WEB_CONCURRENCY=1 invariant)
       ansible.builtin.copy:

--- a/bundles/admin/software.install.deployer_ui/README.md
+++ b/bundles/admin/software.install.deployer_ui/README.md
@@ -27,6 +27,8 @@ The upstream repo ships a multi-stage Dockerfile :
 | `LOCAL_CODE_PATH` | `{{ env RANGE42_GITDIR__ROOT_DIR }}/range42-deployer-ui/` |
 | `REMOTE_PROJECT_DIR` | `/var/www/range42_deployer_ui` |
 | `UI_PORT` | `3000` |
+| `BACKEND_API_URL` | *(unset)* — when set, rendered into `public/config.json` so the SPA pre-registers this backend |
+| `PROXMOX_NODE_NAME` | `pve` — paired with `BACKEND_API_URL` in `config.json` |
 
 ## Call-site example
 
@@ -42,17 +44,40 @@ The upstream repo ships a multi-stage Dockerfile :
 1. **Docker install** : invokes `software.install.warmup.basic_packages` role with `INSTALL_PACKAGES_DOCKER=YES` + `INSTALL_PACKAGES_DOCKER_COMPOSE=YES` (gets Docker Engine + compose plugin via the project's standard install path)
 2. **Firewall** : applies `software.configure.firewalls` role with rules for ports 22 + UI_PORT
 3. **Sync source** : rsync's the deployer-ui repo from the controller to `REMOTE_PROJECT_DIR` (excludes `.git`, `node_modules`, `dist`, `.env*`)
-4. **Template .env** : writes `UI_PORT=<port>` to `<REMOTE_PROJECT_DIR>/.env` for docker-compose to pick up
-5. **Compose up** : runs `docker compose up -d --build` in the project dir (builds the multi-stage image locally on the VM the first time, reuses cached layers afterwards)
-6. **Verify** : waits for the UI port + probes `/health` (expects HTTP 200, content `ok`)
+4. **Record provenance** : captures the controller-side `ref` / short `sha` / dirty-file count of the synced tree into `/var/lib/range42/deployer_ui.version` and echoes it in the play output
+5. **Template .env** : writes `UI_PORT=<port>` to `<REMOTE_PROJECT_DIR>/.env` for docker-compose to pick up
+6. **Render config.json** (only when `BACKEND_API_URL` is set) : writes `<REMOTE_PROJECT_DIR>/public/config.json` before the build, so vite copies it into `dist/` and nginx serves it next to `index.html`
+7. **Compose up** : runs `docker compose up -d --build` in the project dir (builds the multi-stage image locally on the VM the first time, reuses cached layers afterwards)
+8. **Verify** : waits for the UI port + probes `/health` (expects HTTP 200, content `ok`)
+
+## Source provenance
+
+This bundle deploys the **controller's working tree**, not a git clone : branch, local commits and uncommitted edits all ship as-is. That is what makes a dev lab fast (edit, redeploy, no push round-trip), but it also means the deployed bundle can exist on no git remote.
+
+Step 4 therefore records what was actually shipped :
+
+```
+# /var/lib/range42/deployer_ui.version
+repo=range42-deployer-ui
+source_path=/home/alice/range42-deployer-ui/
+ref=dev
+sha=a1b2c3d
+dirty=4
+deployed_at=2026-08-10T09:12:44Z
+```
+
+`dirty=0` is the only evidence that what runs on the VM matches a pushed commit. The file lives outside `REMOTE_PROJECT_DIR` on purpose — inside, its timestamp would bust the Docker build cache on every no-op re-run.
 
 ## Backend connection (CORS path)
 
 The bundled `nginx/default.conf` from the deployer-ui repo serves only the SPA + `/health`. It does NOT proxy `/v1`, `/v0`, `/ws` to the backend. This bundle therefore relies on the **CORS path** :
 
 - The backend (deployer-api-backend) must allow the UI's origin in `Access-Control-Allow-Origin`
-- The backend URL is configured at runtime via the in-app **Settings** modal (no build-time env var needed)
-- Operator workflow : open the UI in a browser → Settings → set backend URL → done
+- The backend URL comes from `config.json` when `BACKEND_API_URL` is set at the call-site, otherwise from the in-app **Settings** modal
+- Operator workflow with `BACKEND_API_URL` : open the UI in a browser → the backend is already registered → done
+- Operator workflow without it : open the UI → Settings → set backend URL → done
+
+The seed is a first-launch default, not a lock : the SPA only applies it when no backend has been registered yet, and records that it was offered, so a host the operator deletes stays deleted.
 
 This is the simplest path for the POC. Production hardening options (out of scope) :
 

--- a/bundles/admin/software.install.deployer_ui/README.md
+++ b/bundles/admin/software.install.deployer_ui/README.md
@@ -63,10 +63,14 @@ source_path=/home/alice/range42-deployer-ui/
 ref=dev
 sha=a1b2c3d
 dirty=4
+upstream=origin/dev
+unpushed=0
 deployed_at=2026-08-10T09:12:44Z
 ```
 
-`dirty=0` is the only evidence that what runs on the VM matches a pushed commit. The file lives outside `REMOTE_PROJECT_DIR` on purpose — inside, its timestamp would bust the Docker build cache on every no-op re-run.
+Reading it: `dirty=0` on its own proves nothing about reproducibility — a commit that was never pushed is perfectly clean, and its sha exists on no remote. The deployed code is recoverable from a remote only when **`dirty=0` and `unpushed=0` and `upstream` is not `none`**. `dirty` is the uncommitted-file count, nothing more.
+
+The file lives outside `REMOTE_PROJECT_DIR` on purpose — inside, its timestamp would bust the Docker build cache on every no-op re-run.
 
 ## Backend connection (CORS path)
 

--- a/bundles/admin/software.install.deployer_ui/bundle_parameters.json
+++ b/bundles/admin/software.install.deployer_ui/bundle_parameters.json
@@ -46,6 +46,21 @@
       "description": "Remote project root where the source is synced and docker compose runs."
     },
     {
+      "name": "BACKEND_API_URL",
+      "type": "string",
+      "required": false,
+      "default_where": "none",
+      "description": "Backend-api base URL rendered into public/config.json before the Docker build, so the SPA registers this deployment's backend on first launch. Unset means no config.json is rendered and the operator sets the backend by hand in the Settings modal."
+    },
+    {
+      "name": "PROXMOX_NODE_NAME",
+      "type": "string",
+      "required": false,
+      "default_where": "bundle-inline",
+      "default": "pve",
+      "description": "Proxmox node the backend targets, paired with BACKEND_API_URL in config.json. Only consumed when BACKEND_API_URL is set."
+    },
+    {
       "name": "INSTALL_TAILSCALE",
       "type": "bool",
       "required": false,

--- a/bundles/admin/software.install.deployer_ui/bundle_parameters.src.yml
+++ b/bundles/admin/software.install.deployer_ui/bundle_parameters.src.yml
@@ -43,6 +43,19 @@ params:
     default: "/var/www/range42_deployer_ui"
     description: Remote project root where the source is synced and docker compose runs.
 
+  - name: BACKEND_API_URL
+    type: string
+    required: false
+    default_where: none
+    description: Backend-api base URL rendered into public/config.json before the Docker build, so the SPA registers this deployment's backend on first launch. Unset means no config.json is rendered and the operator sets the backend by hand in the Settings modal.
+
+  - name: PROXMOX_NODE_NAME
+    type: string
+    required: false
+    default_where: bundle-inline
+    default: "pve"
+    description: Proxmox node the backend targets, paired with BACKEND_API_URL in config.json. Only consumed when BACKEND_API_URL is set.
+
   - name: INSTALL_TAILSCALE
     type: bool
     required: false

--- a/bundles/admin/software.install.deployer_ui/main.yml
+++ b/bundles/admin/software.install.deployer_ui/main.yml
@@ -44,9 +44,13 @@
 #   commits and uncommitted edits included. That is deliberate for a dev lab
 #   (edit, redeploy, no push round-trip), but it means the deployed bundle can
 #   exist on no git remote. So the run records what it shipped in
-#   /var/lib/range42/deployer_ui.version (ref, short sha, dirty file count,
-#   timestamp) and echoes it in the play output. `dirty=0` there is the only
-#   evidence that what runs on the VM matches a pushed commit.
+#   /var/lib/range42/deployer_ui.version (ref, short sha, uncommitted file
+#   count, upstream branch, unpushed commit count, timestamp) and echoes it in
+#   the play output.
+#   Reading it : `dirty=0` alone proves nothing about reproducibility - a
+#   commit that was never pushed is perfectly clean. The deployed sha exists
+#   on a remote only when `dirty=0` AND `unpushed=0` AND `upstream` is not
+#   `none`.
 #   The file lives outside REMOTE_PROJECT_DIR on purpose : inside, its
 #   timestamp would bust the Docker build cache on every no-op re-run.
 #
@@ -165,9 +169,11 @@
       ansible.builtin.shell:
         cmd: |
           cd {{ LOCAL_CODE_PATH_RESOLVED | quote }}
-          printf 'ref=%s\n'   "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
-          printf 'sha=%s\n'   "$(git rev-parse --short HEAD     2>/dev/null || echo unknown)"
-          printf 'dirty=%s\n' "$(git status --porcelain         2>/dev/null | wc -l)"
+          printf 'ref=%s\n'      "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+          printf 'sha=%s\n'      "$(git rev-parse --short HEAD     2>/dev/null || echo unknown)"
+          printf 'dirty=%s\n'    "$(git status --porcelain         2>/dev/null | wc -l)"
+          printf 'upstream=%s\n' "$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || echo none)"
+          printf 'unpushed=%s\n' "$(git rev-list --count '@{upstream}..HEAD' 2>/dev/null || echo unknown)"
         executable: /bin/bash
       delegate_to: localhost
       become: false

--- a/bundles/admin/software.install.deployer_ui/main.yml
+++ b/bundles/admin/software.install.deployer_ui/main.yml
@@ -168,7 +168,9 @@
     - name: Capture controller-side git provenance of the synced source tree
       ansible.builtin.shell:
         cmd: |
-          cd {{ LOCAL_CODE_PATH_RESOLVED | quote }}
+          # Bail rather than run git in the playbook cwd (also a repo) and
+          # stamp the wrong tree. failed_when:false keeps the deploy going.
+          cd {{ LOCAL_CODE_PATH_RESOLVED | quote }} || exit 1
           printf 'ref=%s\n'      "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
           printf 'sha=%s\n'      "$(git rev-parse --short HEAD     2>/dev/null || echo unknown)"
           printf 'dirty=%s\n'    "$(git status --porcelain         2>/dev/null | wc -l)"
@@ -229,8 +231,8 @@
         dest: "{{ REMOTE_PROJECT_DIR_RESOLVED }}/public/config.json"
         content: |
           {
-            "defaultBackendUrl": "{{ BACKEND_API_URL }}",
-            "defaultNodeName": "{{ PROXMOX_NODE_NAME | default('pve') }}"
+            "defaultBackendUrl": {{ BACKEND_API_URL | to_json }},
+            "defaultNodeName": {{ PROXMOX_NODE_NAME | default('pve') | to_json }}
           }
         owner: root
         group: root

--- a/bundles/admin/software.install.deployer_ui/main.yml
+++ b/bundles/admin/software.install.deployer_ui/main.yml
@@ -12,9 +12,14 @@
 #   2. Configure firewall on the host : open UI_PORT, keep 22
 #   3. Sync the deployer-ui source tree from the controller to the VM
 #      (excludes node_modules, .git, dist)
-#   4. Template `.env` on the VM with UI_PORT
-#   5. Run `docker compose up -d --build` in the project dir
-#   6. Wait for /health endpoint to return 200
+#   4. Record the controller-side git provenance of what was just synced in
+#      /var/lib/range42/deployer_ui.version (see "Source provenance" below)
+#   5. Template `.env` on the VM with UI_PORT
+#   6. Render `public/config.json` when BACKEND_API_URL is set, so the SPA
+#      registers this deployment's backend on first launch instead of making
+#      the operator retype the URL in the Settings modal
+#   7. Run `docker compose up -d --build` in the project dir
+#   8. Wait for /health endpoint to return 200
 #
 # REQUIRED vars (passed by the calling scenario via import_playbook `vars:`) :
 #   - global_vm_ssh_name : inventory hostname for the deployer-ui host
@@ -27,6 +32,31 @@
 #                           (default = $RANGE42_GITDIR__ROOT_DIR/range42-deployer-ui/)
 #   - REMOTE_PROJECT_DIR  : remote project root (default /var/www/range42_deployer_ui)
 #   - UI_PORT             : host port the container listens on (default 3000)
+#   - BACKEND_API_URL     : backend-api base URL the SPA should register on
+#                           first launch (e.g. "http://192.168.142.191:8000").
+#                           Unset = no config.json rendered, operator configures
+#                           the backend by hand in the Settings modal.
+#   - PROXMOX_NODE_NAME   : Proxmox node that backend targets, paired with
+#                           BACKEND_API_URL in config.json (default "pve")
+#
+# Source provenance (this bundle deploys the controller's WORKING TREE) :
+#   The rsync below copies the controller's checkout as-is - branch, local
+#   commits and uncommitted edits included. That is deliberate for a dev lab
+#   (edit, redeploy, no push round-trip), but it means the deployed bundle can
+#   exist on no git remote. So the run records what it shipped in
+#   /var/lib/range42/deployer_ui.version (ref, short sha, dirty file count,
+#   timestamp) and echoes it in the play output. `dirty=0` there is the only
+#   evidence that what runs on the VM matches a pushed commit.
+#   The file lives outside REMOTE_PROJECT_DIR on purpose : inside, its
+#   timestamp would bust the Docker build cache on every no-op re-run.
+#
+# Runtime config (config.json) :
+#   Rendered into the source tree's `public/` BEFORE the Docker build, so vite
+#   copies it verbatim into `dist/` and nginx serves it next to index.html.
+#   The SPA fetches /config.json at boot and seeds its backend host list from
+#   it (no-op once the operator has registered or dismissed a host - their
+#   choice always wins). Chosen over a VITE_* build arg so the same source can
+#   target any backend without baking the lab's IP into the image.
 #
 # Backend connection (production) :
 #   The bundled `nginx/default.conf` in the deployer-ui repo serves only the
@@ -131,6 +161,52 @@
           - "--exclude=.env"
           - "--exclude=.env.local"
 
+    - name: Capture controller-side git provenance of the synced source tree
+      ansible.builtin.shell:
+        cmd: |
+          cd {{ LOCAL_CODE_PATH_RESOLVED | quote }}
+          printf 'ref=%s\n'   "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+          printf 'sha=%s\n'   "$(git rev-parse --short HEAD     2>/dev/null || echo unknown)"
+          printf 'dirty=%s\n' "$(git status --porcelain         2>/dev/null | wc -l)"
+        executable: /bin/bash
+      delegate_to: localhost
+      become: false
+      changed_when: false
+      failed_when: false
+      register: ui_src_provenance
+
+    - name: Create /var/lib/range42 (provenance records, outside the build context)
+      ansible.builtin.file:
+        path: /var/lib/range42
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Record what was actually deployed (ref + sha + dirty state)
+      ansible.builtin.copy:
+        dest: /var/lib/range42/deployer_ui.version
+        content: |
+          # Managed by range42 / bundles/admin/software.install.deployer_ui
+          # Provenance of the source tree rsynced from the controller.
+          # dirty > 0 means this deploy carries uncommitted controller-side
+          # edits and matches no commit on any remote.
+          repo=range42-deployer-ui
+          source_path={{ LOCAL_CODE_PATH_RESOLVED }}
+          {% for line in ui_src_provenance.stdout_lines %}
+          {{ line }}
+          {% endfor %}
+          deployed_at={{ ansible_facts.date_time.iso8601 }}
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Show the deployed source provenance
+      ansible.builtin.debug:
+        msg: >-
+          deployer-ui source :
+          {{ ui_src_provenance.stdout_lines | join(' ') | default('unknown', true) }}
+
     - name: Template /var/www/range42_deployer_ui/.env (UI_PORT)
       ansible.builtin.copy:
         dest: "{{ REMOTE_PROJECT_DIR_RESOLVED }}/.env"
@@ -141,6 +217,21 @@
         owner: root
         group: root
         mode: "0644"
+
+    - name: Render public/config.json (backend the SPA registers on first launch)
+      ansible.builtin.copy:
+        dest: "{{ REMOTE_PROJECT_DIR_RESOLVED }}/public/config.json"
+        content: |
+          {
+            "defaultBackendUrl": "{{ BACKEND_API_URL }}",
+            "defaultNodeName": "{{ PROXMOX_NODE_NAME | default('pve') }}"
+          }
+        owner: root
+        group: root
+        mode: "0644"
+      when: BACKEND_API_URL | default('') | length > 0
+      # No else-branch needed : config.json is not tracked in the repo, so the
+      # rsync --delete above already removed any stale copy before this point.
 
     - name: Run docker compose up -d --build
       ansible.builtin.command:

--- a/scenarios/dev_deployer_ui_lab/02_dev_deployer_ui_lab_infrastructure/stage_01-vm_configure/dev-deployer-ui.yml
+++ b/scenarios/dev_deployer_ui_lab/02_dev_deployer_ui_lab_infrastructure/stage_01-vm_configure/dev-deployer-ui.yml
@@ -20,3 +20,8 @@
   vars:
     global_vm_ssh_name: "r42.dev-deployer-ui"
     global_vm_ci_ip:    "192.168.142.190"
+    # Pre-register this lab's backend (dev-backend, 192.168.142.191) in the SPA
+    # so a fresh deploy is usable without the operator retyping the URL in the
+    # Settings modal. Rendered to public/config.json before the Docker build ;
+    # the operator can still add / switch / delete backends from the UI.
+    BACKEND_API_URL: "http://192.168.142.191:8000"

--- a/scenarios/dev_deployer_ui_lab/dev_deployer_ui_lab.reset.setup.sh
+++ b/scenarios/dev_deployer_ui_lab/dev_deployer_ui_lab.reset.setup.sh
@@ -36,6 +36,15 @@ done
 ## Trailing "$@" propagates any extra args to ansible-playbook.
 ##
 
+# Fail fast on a stale workspace. `RANGE42_BUNDLE_DIR` anchors every
+# `import_playbook` in this scenario and is exported by `sourced_range42`. A
+# workspace generated before that export exists resolves every bundle path to
+# `/admin/...` and dies with an opaque "the playbook could not be found".
+# Fix: re-run the workspace.credentials role (or `range42-context` re-init) to
+# regenerate `sourced_range42`, then `range42-context use <codename> <scenario>`.
+: "${RANGE42_BUNDLE_DIR:?RANGE42_BUNDLE_DIR is not set - your workspace predates the bundle-root export ; regenerate sourced_range42 and re-run: range42-context use <codename> dev_deployer_ui_lab}"
+: "${RANGE42_ANSIBLE_ROLES__INVENTORY_DIR:?RANGE42_ANSIBLE_ROLES__INVENTORY_DIR is not set - run: range42-context use <codename> dev_deployer_ui_lab}"
+
 ansible-playbook -i "${RANGE42_ANSIBLE_ROLES__INVENTORY_DIR}/inventory_default.yml" \
 	-l "all" \
 	"./main.yml" --vault-password-file "${RANGE42_VAULT_PASSWORD_FILE:?RANGE42_VAULT_PASSWORD_FILE is not set - run: range42-context use <codename> <scenario>}" \

--- a/scenarios/dev_deployer_ui_lab/dev_deployer_ui_lab.reset.setup.sh
+++ b/scenarios/dev_deployer_ui_lab/dev_deployer_ui_lab.reset.setup.sh
@@ -4,6 +4,20 @@
 ## reset - delete this scenario's VMs (filter by vm_id from manifest) then re-deploy
 ##
 
+# Environment checks run FIRST, before the delete block below. This script
+# destroys the lab and then redeploys it ; a guard placed after the deletion
+# would leave the operator with neither -- VMs gone, redeploy refused.
+# Fail fast on a stale workspace. `RANGE42_BUNDLE_DIR` anchors every
+# `import_playbook` in this scenario and is exported by `sourced_range42`. A
+# workspace generated before that export exists resolves every bundle path to
+# `/admin/...` and dies with an opaque "the playbook could not be found".
+# Fix: re-run the workspace.credentials role (or `range42-context` re-init) to
+# regenerate `sourced_range42`, then `range42-context use <codename> <scenario>`.
+: "${RANGE42_BUNDLE_DIR:?RANGE42_BUNDLE_DIR is not set - your workspace predates the bundle-root export ; regenerate sourced_range42 and re-run: range42-context use <codename> dev_deployer_ui_lab}"
+: "${RANGE42_ANSIBLE_ROLES__INVENTORY_DIR:?RANGE42_ANSIBLE_ROLES__INVENTORY_DIR is not set - run: range42-context use <codename> dev_deployer_ui_lab}"
+
+: "${RANGE42_VAULT_PASSWORD_FILE:?RANGE42_VAULT_PASSWORD_FILE is not set - run: range42-context use <codename> <scenario>}"
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MANIFEST="$SCRIPT_DIR/manifest/scenario_vms.json"
 
@@ -36,16 +50,7 @@ done
 ## Trailing "$@" propagates any extra args to ansible-playbook.
 ##
 
-# Fail fast on a stale workspace. `RANGE42_BUNDLE_DIR` anchors every
-# `import_playbook` in this scenario and is exported by `sourced_range42`. A
-# workspace generated before that export exists resolves every bundle path to
-# `/admin/...` and dies with an opaque "the playbook could not be found".
-# Fix: re-run the workspace.credentials role (or `range42-context` re-init) to
-# regenerate `sourced_range42`, then `range42-context use <codename> <scenario>`.
-: "${RANGE42_BUNDLE_DIR:?RANGE42_BUNDLE_DIR is not set - your workspace predates the bundle-root export ; regenerate sourced_range42 and re-run: range42-context use <codename> dev_deployer_ui_lab}"
-: "${RANGE42_ANSIBLE_ROLES__INVENTORY_DIR:?RANGE42_ANSIBLE_ROLES__INVENTORY_DIR is not set - run: range42-context use <codename> dev_deployer_ui_lab}"
-
 ansible-playbook -i "${RANGE42_ANSIBLE_ROLES__INVENTORY_DIR}/inventory_default.yml" \
 	-l "all" \
-	"./main.yml" --vault-password-file "${RANGE42_VAULT_PASSWORD_FILE:?RANGE42_VAULT_PASSWORD_FILE is not set - run: range42-context use <codename> <scenario>}" \
+	"./main.yml" --vault-password-file "${RANGE42_VAULT_PASSWORD_FILE}" \
 	"$@"

--- a/scenarios/dev_deployer_ui_lab/dev_deployer_ui_lab.setup.sh
+++ b/scenarios/dev_deployer_ui_lab/dev_deployer_ui_lab.setup.sh
@@ -13,6 +13,15 @@
 ## See ./manifest/feature_flags.yml for the list of toggleable features.
 ##
 
+# Fail fast on a stale workspace. `RANGE42_BUNDLE_DIR` anchors every
+# `import_playbook` in this scenario and is exported by `sourced_range42`. A
+# workspace generated before that export exists resolves every bundle path to
+# `/admin/...` and dies with an opaque "the playbook could not be found".
+# Fix: re-run the workspace.credentials role (or `range42-context` re-init) to
+# regenerate `sourced_range42`, then `range42-context use <codename> <scenario>`.
+: "${RANGE42_BUNDLE_DIR:?RANGE42_BUNDLE_DIR is not set - your workspace predates the bundle-root export ; regenerate sourced_range42 and re-run: range42-context use <codename> dev_deployer_ui_lab}"
+: "${RANGE42_ANSIBLE_ROLES__INVENTORY_DIR:?RANGE42_ANSIBLE_ROLES__INVENTORY_DIR is not set - run: range42-context use <codename> dev_deployer_ui_lab}"
+
 ansible-playbook -i "${RANGE42_ANSIBLE_ROLES__INVENTORY_DIR}/inventory_default.yml" \
 	-l "all" \
 	"./main.yml" --vault-password-file "${RANGE42_VAULT_PASSWORD_FILE:?RANGE42_VAULT_PASSWORD_FILE is not set - run: range42-context use <codename> <scenario>}" \

--- a/scenarios/dev_deployer_ui_lab/dev_deployer_ui_lab.setup_vms_only.sh
+++ b/scenarios/dev_deployer_ui_lab/dev_deployer_ui_lab.setup_vms_only.sh
@@ -9,6 +9,15 @@
 ## `range42-context deploy-vms`.
 ##
 
+# Fail fast on a stale workspace. `RANGE42_BUNDLE_DIR` anchors every
+# `import_playbook` in this scenario and is exported by `sourced_range42`. A
+# workspace generated before that export exists resolves every bundle path to
+# `/admin/...` and dies with an opaque "the playbook could not be found".
+# Fix: re-run the workspace.credentials role (or `range42-context` re-init) to
+# regenerate `sourced_range42`, then `range42-context use <codename> <scenario>`.
+: "${RANGE42_BUNDLE_DIR:?RANGE42_BUNDLE_DIR is not set - your workspace predates the bundle-root export ; regenerate sourced_range42 and re-run: range42-context use <codename> dev_deployer_ui_lab}"
+: "${RANGE42_ANSIBLE_ROLES__INVENTORY_DIR:?RANGE42_ANSIBLE_ROLES__INVENTORY_DIR is not set - run: range42-context use <codename> dev_deployer_ui_lab}"
+
 ansible-playbook -i "${RANGE42_ANSIBLE_ROLES__INVENTORY_DIR}/inventory_default.yml" \
 	-l "all" \
 	"./main_vms_only.yml" --vault-password-file "${RANGE42_VAULT_PASSWORD_FILE:?RANGE42_VAULT_PASSWORD_FILE is not set - run: range42-context use <codename> <scenario>}" \


### PR DESCRIPTION
Stacked on #134 — merge that first, GitHub will retarget this to `dev` automatically.

Three ways the lab came up deployed-but-not-usable. None of them were visible from the deploy output.

### 1. Stale workspace, opaque failure

Every `import_playbook` in this scenario is anchored on `RANGE42_BUNDLE_DIR`, exported by `sourced_range42`. A workspace generated before that export exists resolves every bundle path to `/admin/...` and dies with "the playbook could not be found" — nothing points at the actual cause.

The three entry scripts now guard the variable the same way they already guard `RANGE42_VAULT_PASSWORD_FILE`, and the message names the fix (regenerate `sourced_range42`, re-run `range42-context use`). Verified: with the variable unset the script exits 1 before reaching `ansible-playbook`.

Note the root cause is upstream — `range42` `main` is 23 commits behind `dev`, which is where the export lives.

### 2. No record of what was actually deployed

Both bundles rsync the **controller's working tree**, not a git clone — branch, local commits and uncommitted edits all ship. That is deliberate for a dev lab, but it means what runs on the VM can exist on no git remote, and nothing said so.

Each run now records ref / short sha / dirty file count and echoes it in the play output:

```
# /var/lib/range42/deployer_ui.version
repo=range42-deployer-ui
ref=dev
sha=257e62a
dirty=4
deployed_at=2026-08-10T09:12:44Z
```

`dirty=0` is the only evidence a deploy matches a pushed commit. The backend bundle stamps **both** trees it syncs — backend-api and playbooks (the latter is what the in-container ansible-runner reads).

Kept outside `REMOTE_PROJECT_DIR` on purpose: inside, the timestamp would bust the Docker build cache on every no-op re-run.

### 3. Backend URL retyped by hand on every fresh lab

The `deployer_ui` bundle now renders `public/config.json` from a new `BACKEND_API_URL` var before the Docker build, so vite copies it into `dist/` and nginx serves it beside `index.html`. The SPA seeds its backend host list from it on boot.

Runtime rather than a `VITE_` build arg, so one source tree targets any backend without a rebuild. The seed is a first-launch default, not a lock — it no-ops once a host is registered, and records that it was offered so a host the operator deletes stays deleted.

Paired with range42/range42-deployer-ui@257e62a (already on `dev`).

### Verified

- `ansible-playbook --syntax-check` green on the full scenario after each step
- Both bundles' new tasks executed for real against localhost — version files render correctly and `config.json` parses as JSON matching the shape the UI tests assert on
- Caught in the process: a first cut used `join('\n')`, which emitted a literal `\n` mid-file. Replaced with a Jinja loop and re-run.