### PR TITLE
fix(terminfo): harden systems.configure.terminfo — no silent no-op, sshd validate, required terminfo_hosts

### DIFF
--- a/bundles/generic/systems.configure.terminfo/README.md
+++ b/bundles/generic/systems.configure.terminfo/README.md
@@ -4,9 +4,13 @@ Installs the alacritty terminfo entry on a target group and lets sshd accept the
 client `TERM` value, so `TERM=alacritty` no longer breaks remote sessions on
 Ubuntu minimal images.
 
-Caller vars: `terminfo_hosts` (inventory group the play targets ; falls back to
-`all`).
+Caller vars: `terminfo_hosts` (inventory group the play targets ; **required** —
+scenario inventories carry `proxmox`/`proxmox_cli` groups, so an implicit `all`
+would rewrite sshd config on the hypervisor and the deployer).
 
 The terminfo binary is copied from the Ansible controller
-(`/usr/share/terminfo/a/alacritty`) ; the copy is best-effort, so the play is a
-no-op when the controller has no alacritty entry.
+(`/usr/share/terminfo/a/alacritty`). The play checks the controller first and
+prints an explicit skip warning when the entry is missing (install `alacritty`
+or `ncurses-term` on the controller), instead of failing silently. The sshd
+edit is guarded by `validate: sshd -t`, so a config that would not parse is
+never written.

--- a/bundles/generic/systems.configure.terminfo/bundle_parameters.json
+++ b/bundles/generic/systems.configure.terminfo/bundle_parameters.json
@@ -10,9 +10,8 @@
       "target": true,
       "type": "string",
       "required": true,
-      "default_where": "bundle-inline",
-      "default": "all",
-      "description": "Ansible inventory group the play targets (used in hosts) ; falls back to all when the caller omits it"
+      "default_where": "call-site",
+      "description": "Ansible inventory group the play targets (used in hosts) ; required, no fallback — an implicit all would touch the hypervisor and deployer"
     }
   ]
 }

--- a/bundles/generic/systems.configure.terminfo/bundle_parameters.src.yml
+++ b/bundles/generic/systems.configure.terminfo/bundle_parameters.src.yml
@@ -10,6 +10,5 @@ params:
     target: true
     type: string
     required: true
-    default_where: bundle-inline
-    default: "all"
-    description: Ansible inventory group the play targets (used in hosts) ; falls back to all when the caller omits it
+    default_where: call-site
+    description: Ansible inventory group the play targets (used in hosts) ; required, no fallback — an implicit all would touch the hypervisor and deployer

--- a/bundles/generic/systems.configure.terminfo/main.yml
+++ b/bundles/generic/systems.configure.terminfo/main.yml
@@ -11,7 +11,9 @@
 ##
 ## Caller: scenarios import this via `import_playbook` in their stage_01,
 ## passing `terminfo_hosts` to scope the play to the relevant inventory group
-## (e.g. `r42_admin_services_lab_group`). Defaults to `all` for backward compat.
+## (e.g. `r42_admin_services_lab_group`). The var is required: scenario
+## inventories carry proxmox/proxmox_cli groups, so an implicit `all` would
+## rewrite sshd config on the hypervisor and the deployer.
 ## Relates to: range42/range42#227
 ##
 ## Import:
@@ -21,7 +23,7 @@
 ##
 
 - name: configure sshd and alacritty terminfo
-  hosts: "{{ terminfo_hosts | default('all') }}"
+  hosts: "{{ terminfo_hosts }}"
   become: true
   tasks:
     - name: allow SSH client to forward TERM environment variable
@@ -30,6 +32,7 @@
         regexp: '^AcceptEnv TERM'
         insertafter: '^AcceptEnv LANG LC_\*'
         line: 'AcceptEnv TERM'
+        validate: '/usr/sbin/sshd -t -f %s'
       notify: reload sshd
 
     - name: ensure /etc/terminfo/a directory exists
@@ -38,12 +41,28 @@
         state: directory
         mode: '0755'
 
+    - name: check whether the controller has the alacritty terminfo entry
+      ansible.builtin.stat:
+        path: /usr/share/terminfo/a/alacritty
+      delegate_to: localhost
+      run_once: true
+      become: false
+      register: controller_alacritty_terminfo
+
     - name: install alacritty terminfo so TERM=alacritty works over SSH
       ansible.builtin.copy:
         src: /usr/share/terminfo/a/alacritty
         dest: /etc/terminfo/a/alacritty
         mode: '0644'
-      ignore_errors: true
+      when: controller_alacritty_terminfo.stat.exists
+
+    - name: warn when the controller cannot provide the alacritty terminfo
+      ansible.builtin.debug:
+        msg: >-
+          Skipping terminfo install: /usr/share/terminfo/a/alacritty not found
+          on the controller. Install alacritty or ncurses-term on the controller
+          and re-run this bundle.
+      when: not controller_alacritty_terminfo.stat.exists
 
   handlers:
     - name: reload sshd


### PR DESCRIPTION
## Summary

Hardens `bundles/generic/systems.configure.terminfo` (merged via #141), addressing the review feedback that carried over from the superseded #135:

- **Drop `ignore_errors: true`** on the terminfo copy — the play now `stat`s `/usr/share/terminfo/a/alacritty` on the controller first, copies only when present, and emits an explicit skip warning otherwise. Previously a headless controller without Alacritty produced a green run that installed nothing.
- **Add `validate: '/usr/sbin/sshd -t -f %s'`** to the `sshd_config` edit — a config that would not parse is never written, instead of surviving until the next full sshd restart and locking the host out.
- **Require `terminfo_hosts`** (drop `default('all')`) — scenario inventories carry `proxmox`/`proxmox_cli` groups, so a caller forgetting the var would rewrite sshd config on the hypervisor and the deployer. Matches the `TARGET_GROUP` pattern used by the other `generic/` bundles. The only existing caller (`admin_services_lab` stage_01) already passes it explicitly.

`README.md` and `bundle_parameters` updated to match (`default_where: call-site`, no default); JSON regenerated with `bundles/_tools/generate-bundle-params.py`.

cc @pparage — this picks up your non-blocking findings from #135.

Relates to range42/range42#227.

## Not addressed (deliberate)

`insertafter: '^AcceptEnv LANG LC_\*'` can still fall back to EOF and land inside a trailing `Match` block on exotic configs. Moving to an `/etc/ssh/sshd_config.d/` drop-in would sidestep it, but that changes the bundle's editing strategy — left for a separate change if it bites.

## Test plan

- [x] `ansible-playbook --syntax-check` (ansible-core, `-e terminfo_hosts=<group>`) — pass
- [x] `ansible-lint` — the previous `ignore-errors` violation is gone; the remaining standalone `syntax-check[specific]` complaint about the undefined `hosts` var is shared by every templated-hosts bundle in the repo (no lint CI configured)
- [ ] Run `admin_services_lab` stage_01 against the lab; confirm skip warning appears when the controller lacks the terminfo entry, and the copy + sshd reload work when it does
