### PR TITLE
fix(deployer_ui): seed config.json with the node the workspace targets (#131)

### DIFF
--- a/bundles/admin/software.install.deployer_ui/README.md
+++ b/bundles/admin/software.install.deployer_ui/README.md
@@ -28,7 +28,7 @@ The upstream repo ships a multi-stage Dockerfile :
 | `REMOTE_PROJECT_DIR` | `/var/www/range42_deployer_ui` |
 | `UI_PORT` | `3000` |
 | `BACKEND_API_URL` | *(unset)* — when set, rendered into `public/config.json` so the SPA pre-registers this backend |
-| `PROXMOX_NODE_NAME` | `pve` — paired with `BACKEND_API_URL` in `config.json` |
+| `PROXMOX_NODE_NAME` | `proxmox_node` from the workspace vault, else `pve` — paired with `BACKEND_API_URL` in `config.json` |
 
 ## Call-site example
 

--- a/bundles/admin/software.install.deployer_ui/bundle_parameters.json
+++ b/bundles/admin/software.install.deployer_ui/bundle_parameters.json
@@ -57,8 +57,8 @@
       "type": "string",
       "required": false,
       "default_where": "bundle-inline",
-      "default": "pve",
-      "description": "Proxmox node the backend targets, paired with BACKEND_API_URL in config.json. Only consumed when BACKEND_API_URL is set."
+      "default": "proxmox_node from the workspace vault, else pve",
+      "description": "Proxmox node the backend targets, paired with BACKEND_API_URL in config.json. Defaults to the workspace vault's proxmox_node so a fresh lab seeds the node it actually deploys to; the literal \"pve\" is only the last-resort fallback. Only consumed when BACKEND_API_URL is set."
     },
     {
       "name": "INSTALL_TAILSCALE",

--- a/bundles/admin/software.install.deployer_ui/bundle_parameters.src.yml
+++ b/bundles/admin/software.install.deployer_ui/bundle_parameters.src.yml
@@ -53,8 +53,8 @@ params:
     type: string
     required: false
     default_where: bundle-inline
-    default: "pve"
-    description: Proxmox node the backend targets, paired with BACKEND_API_URL in config.json. Only consumed when BACKEND_API_URL is set.
+    default: "proxmox_node from the workspace vault, else pve"
+    description: Proxmox node the backend targets, paired with BACKEND_API_URL in config.json. Defaults to the workspace vault's proxmox_node so a fresh lab seeds the node it actually deploys to; the literal "pve" is only the last-resort fallback. Only consumed when BACKEND_API_URL is set.
 
   - name: INSTALL_TAILSCALE
     type: bool

--- a/bundles/admin/software.install.deployer_ui/main.yml
+++ b/bundles/admin/software.install.deployer_ui/main.yml
@@ -37,7 +37,10 @@
 #                           Unset = no config.json rendered, operator configures
 #                           the backend by hand in the Settings modal.
 #   - PROXMOX_NODE_NAME   : Proxmox node that backend targets, paired with
-#                           BACKEND_API_URL in config.json (default "pve")
+#                           BACKEND_API_URL in config.json. Defaults to
+#                           `proxmox_node` from the workspace vault, so the
+#                           node is right without the call-site restating it ;
+#                           falls back to "pve" only when neither is set.
 #
 # Source provenance (this bundle deploys the controller's WORKING TREE) :
 #   The rsync below copies the controller's checkout as-is - branch, local
@@ -133,10 +136,17 @@
 - name: install deployer-ui - sync source + .env + docker compose up
   hosts: "{{ global_vm_ssh_name }}"
   become: true
+  vars_files:
+    # For `proxmox_node` — the node this workspace actually targets. Without it
+    # config.json would seed the literal "pve" on every deployment and the
+    # operator would still have to fix the node by hand in Settings, which is
+    # the exact retyping this file exists to remove.
+    - "{{ lookup('env', 'RANGE42_ACTIVE_CONFIG_DIR') }}/secrets/default_vault.yml"
   vars:
     LOCAL_CODE_PATH_RESOLVED: "{{ LOCAL_CODE_PATH | default(lookup('env', 'RANGE42_GITDIR__ROOT_DIR') + '/range42-deployer-ui/', true) }}"
     REMOTE_PROJECT_DIR_RESOLVED: "{{ REMOTE_PROJECT_DIR | default('/var/www/range42_deployer_ui') }}"
     UI_PORT_RESOLVED: "{{ UI_PORT | default('3000') }}"
+    PROXMOX_NODE_NAME_RESOLVED: "{{ PROXMOX_NODE_NAME | default(proxmox_node | default('pve', true), true) }}"
   tasks:
     - name: Install rsync on remote (required for synchronize)
       ansible.builtin.apt:
@@ -232,7 +242,7 @@
         content: |
           {
             "defaultBackendUrl": {{ BACKEND_API_URL | to_json }},
-            "defaultNodeName": {{ PROXMOX_NODE_NAME | default('pve') | to_json }}
+            "defaultNodeName": {{ PROXMOX_NODE_NAME_RESOLVED | to_json }}
           }
         owner: root
         group: root


### PR DESCRIPTION
Part of #131 — the "feed the runtime variables to the containers at deploy, from the active workspace vault" half of the split.

### The bug

`config.json` renders `defaultNodeName` from `PROXMOX_NODE_NAME`, defaulting to the literal `"pve"`. No scenario call-site passes it, so **every** deployment seeds `"pve"` no matter which node it just deployed to.

Caught on a live `dev_deployer_ui_lab` run: the backend registers the Proxmox host as `node_name: "pve01"`, while the SPA sitting next to it seeds `"pve"`. The operator still has to fix the node by hand in Settings — the exact retyping `config.json` was added to remove, so the seeding fix was only half working.

### The fix

Resolve the default from the active workspace vault's `proxmox_node`:

```yaml
PROXMOX_NODE_NAME_RESOLVED: "{{ PROXMOX_NODE_NAME | default(proxmox_node | default('pve', true), true) }}"
```

The vault is loaded with the same `vars_files` pattern `proxmox/vm.bootstrap`, the `cloud_init_image.download.*` bundles and the `template.build.*` bundles already use, so this introduces no new convention.

Fixed in the bundle rather than at the call-site on purpose: passing `pve01` in `dev-deployer-ui.yml` would bake a site-specific node into an open-source scenario, and would leave every other scenario broken.

### Verified

Against the real workspace vault, both branches:

| Case | `defaultNodeName` |
|---|---|
| nothing passed (the `dev_deployer_ui_lab` case) | `pve01` — was `pve` |
| `-e PROXMOX_NODE_NAME=pve99` | `pve99` — explicit override still wins |

Output parses as JSON. Scenario `--syntax-check` green.

Contract docs updated to match (header comment, `README.md`, `bundle_parameters.src.yml`) and `bundles/_tools/generate-bundle-params.py` re-run — it regenerates all 56 bundles but only this one changed.

### Pairs with

range42/range42-deployer-ui@ba20ba2 — the container was permanently `unhealthy` because the `HEALTHCHECK` called `wget`, which does not exist in `nginx:stable-bookworm`. Already on `dev`.